### PR TITLE
Markdown formatting, message list item formatting

### DIFF
--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -79,7 +79,7 @@ class MessageDetailComponent extends React.PureComponent<Props, never> {
 
           {/* Subject */}
           <View style={styles.subjectContainer}>
-            <H1>{message.content.subject}</H1>
+            <H1 style={{lineHeight:40}}>{message.content.subject}</H1>
           </View>
 
           {/* RawInfo */}
@@ -97,7 +97,10 @@ class MessageDetailComponent extends React.PureComponent<Props, never> {
         />
 
         <View style={styles.markdownContainer}>
-          <Markdown lazyOptions={{ lazy: true }}>
+          <Markdown
+            lazyOptions={{ lazy: true }}
+            initialState={{ screen: "MESSAGE_DETAIL" }}
+          >
             {message.content.markdown}
           </Markdown>
         </View>

--- a/ts/components/messages/MessageListItemComponent.tsx
+++ b/ts/components/messages/MessageListItemComponent.tsx
@@ -40,7 +40,8 @@ const styles = StyleSheet.create({
   },
 
   serviceText: {
-    fontSize: variables.fontSize3
+    fontSize: variables.fontSize3,
+    lineHeight: 20
   },
 
   dateText: {
@@ -91,7 +92,7 @@ export class MessageListItemComponent extends React.PureComponent<
         <View style={styles.itemContainer}>
           <Grid style={styles.grid}>
             <Row style={styles.serviceRow}>
-              <Col>
+              <Col size={10}>
                 <Text
                   style={styles.serviceText}
                   leftAlign={true}
@@ -100,7 +101,7 @@ export class MessageListItemComponent extends React.PureComponent<
                   {uiService}
                 </Text>
               </Col>
-              <Col>
+              <Col size={2}>
                 <Text style={styles.dateText} rightAlign={true}>
                   {uiCreatedAt}
                 </Text>

--- a/ts/components/ui/Markdown/rules/heading.ts
+++ b/ts/components/ui/Markdown/rules/heading.ts
@@ -34,7 +34,8 @@ function rule() {
       return React.createElement(
         ComponentType,
         {
-          key: state.key
+          key: state.key,
+          inMessage: state.screen === "MESSAGE_DETAIL" ? true : false
         },
         output(node.content, newState)
       );

--- a/ts/components/ui/Markdown/rules/text.ts
+++ b/ts/components/ui/Markdown/rules/text.ts
@@ -23,7 +23,8 @@ function rule() {
         Text,
         {
           key: i,
-          markdown: true
+          markdown: true,
+          inMessage: state.screen === "MESSAGE_DETAIL" ? true : false
         },
         text
       );

--- a/ts/theme/components/H1.ts
+++ b/ts/theme/components/H1.ts
@@ -1,14 +1,28 @@
-import { Platform } from "react-native";
+import { Platform, TextProperties } from "react-native";
 
 import { makeFontStyleObject } from "../fonts";
 import { Theme } from "../types";
 import variables from "../variables";
+
+declare module "native-base" {
+  namespace NativeBase {
+    interface H1 extends TextProperties {
+      inMessage?: boolean;
+    }
+  }
+}
 
 export default (): Theme => {
   return {
     ...makeFontStyleObject(Platform.select, variables.h1FontWeight),
     color: variables.h1Color,
     fontSize: variables.h1FontSize,
-    lineHeight: variables.h1LineHeight
+    lineHeight: variables.h1LineHeight,
+    ".inMessage": {
+      marginTop: variables.fontSizeBase * 2,
+      marginBottom: variables.fontSizeBase * 0.75,
+      lineHeight: 36,
+      fontSize: variables.fontSize6
+    }
   };
 };

--- a/ts/theme/components/H2.ts
+++ b/ts/theme/components/H2.ts
@@ -9,6 +9,12 @@ export default (): Theme => {
     ...makeFontStyleObject(Platform.select, variables.h2FontWeight),
     color: variables.h2Color,
     fontSize: variables.h2FontSize,
-    lineHeight: variables.h2LineHeight
+    lineHeight: variables.h2LineHeight,
+    ".inMessage": {
+      marginTop: variables.fontSizeBase * 1.75,
+      marginBottom: variables.fontSizeBase * 0.5,
+      lineHeight: 32,
+      fontSize: variables.fontSize5
+    }
   };
 };

--- a/ts/theme/components/H3.ts
+++ b/ts/theme/components/H3.ts
@@ -9,6 +9,12 @@ export default (): Theme => {
     ...makeFontStyleObject(Platform.select, variables.h3FontWeight),
     color: variables.h3Color,
     fontSize: variables.h3FontSize,
-    lineHeight: variables.h3LineHeight
+    lineHeight: variables.h3LineHeight,
+    ".inMessage": {
+      marginTop: variables.fontSizeBase * 1.5,
+      marginBottom: variables.fontSizeBase * 0.5,
+      lineHeight: 24,
+      fontSize: variables.fontSize4
+    }
   };
 };

--- a/ts/theme/components/Text.ts
+++ b/ts/theme/components/Text.ts
@@ -17,6 +17,7 @@ declare module "native-base" {
       alignCenter?: boolean;
       primary?: boolean;
       markdown?: boolean;
+      inMessage?: boolean;
     }
   }
 }
@@ -65,6 +66,9 @@ export default (): Theme => {
         borderRadius: variables.borderRadiusBase,
         color: variables.colorWhite,
         backgroundColor: variables.textLinkColor
+      },
+      ".inMessage": {
+        lineHeight: variables.lineHeightBase + 0
       }
     },
     lineHeight: variables.lineHeightBase


### PR DESCRIPTION
TODO:

- fix paragraph spacing (bottom margin is missing)
- fix new line line breaks
- fix quote (it does not appear at all)
- indent list

The following markdown text

``` Donec sed odio operae, eu vulputate felis rhoncus. Tityre, tu patulae recubans sub tegmine fagi dolor. At nos hinc posthac, sitientis piros Afros. Non equidem invideo, miror magis posuere velit aliquet.  
Hi omnes lingua, institutis, legibus inter se differunt. Quae vero auctorem tractata ab fiducia dicuntur. Plura mihi bona sunt, inclinet, amari petere vellent. Sed haec quis possit intrepidus aestimare tellus. Curabitur blandit tempus ardua ridiculus sed magna.


Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Fabio vel iudice vincam, sunt in culpa qui officia.


> Quote o indent
```
is rendered this way:

![paragraph rendering](https://user-images.githubusercontent.com/8171284/46489213-17884b80-c805-11e8-9e81-818cab949fda.jpg)


