### PR TITLE
[#162158329] Header - clickable "back" labels within sections

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -493,8 +493,6 @@ services:
   contactsAndInfo: Contacts and info
   contactAddress: Address
   contactPhone: Phone
-serviceDetail:
-  headerTitle: "Service details"
 identification:
   message: "Enter the PIN"
   resetPinMessage: To reset your PIN you will have to login again with your SPID account.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -505,8 +505,6 @@ services:
   contactsAndInfo: Contatti ed informazioni
   contactAddress: Indirizzo
   contactPhone: Telefono
-serviceDetail:
-  headerTitle: "Dettagli del Servizio"
 identification:
   message: "Inserisci il PIN"
   resetPinMessage: Per reimpostare il tuo PIN dovrai accedere nuovamente con la tua identità SPID.

--- a/ts/components/screens/BaseHeader.tsx
+++ b/ts/components/screens/BaseHeader.tsx
@@ -36,7 +36,7 @@ export class BaseHeader extends React.PureComponent<Props> {
           </Left>
         )}
         <Body>
-          <Text white={this.props.primary} numberOfLines={1}>
+          <Text white={this.props.primary} numberOfLines={1} onPress={goBack}>
             {headerTitle || DEFAULT_APPLICATION_NAME}
           </Text>
         </Body>

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -20,11 +20,15 @@ import {
 import * as React from "react";
 import { ScrollView, StyleSheet } from "react-native";
 
+import { connect } from "react-redux";
+import { navigateToWalletHome } from "../../store/actions/navigation";
+import { Dispatch } from "../../store/actions/types";
+import { InstabugButtons } from "../InstabugButtons";
+import { WalletStyles } from "../styles/wallet";
+
 import I18n from "../../i18n";
 import variables from "../../theme/variables";
 import GoBackButton from "../GoBackButton";
-import { InstabugButtons } from "../InstabugButtons";
-import { WalletStyles } from "../styles/wallet";
 import AppHeader from "../ui/AppHeader";
 import IconFont from "../ui/IconFont";
 
@@ -34,7 +38,11 @@ const styles = StyleSheet.create({
   }
 });
 
-type Props = Readonly<{
+type ReduxMappedDispatchProps = Readonly<{
+  navigateToWalletHome: () => void;
+}>;
+
+type OwnProps = Readonly<{
   title: string;
   headerContents?: React.ReactNode;
   onNewPaymentPress?: () => void;
@@ -42,7 +50,9 @@ type Props = Readonly<{
   displayedWallets?: React.ReactNode;
 }>;
 
-export default class WalletLayout extends React.Component<Props> {
+type Props = ReduxMappedDispatchProps & OwnProps;
+
+class WalletLayout extends React.Component<Props> {
   public render(): React.ReactNode {
     return (
       <Container>
@@ -53,7 +63,17 @@ export default class WalletLayout extends React.Component<Props> {
             </Left>
           )}
           <Body>
-            <Text style={WalletStyles.white}>{this.props.title}</Text>
+            <Text
+              style={WalletStyles.white}
+              numberOfLines={1}
+              onPress={
+                this.props.allowGoBack
+                  ? this.props.navigateToWalletHome
+                  : undefined
+              }
+            >
+              {this.props.title}
+            </Text>
           </Body>
           <Right>
             <InstabugButtons color={variables.colorWhite} />
@@ -82,3 +102,12 @@ export default class WalletLayout extends React.Component<Props> {
     );
   }
 }
+
+const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
+  navigateToWalletHome: () => dispatch(navigateToWalletHome())
+});
+
+export default connect(
+  undefined,
+  mapDispatchToProps
+)(WalletLayout);

--- a/ts/screens/messages/MessageDetailScreen.tsx
+++ b/ts/screens/messages/MessageDetailScreen.tsx
@@ -188,7 +188,7 @@ export class MessageDetailScreen extends React.PureComponent<Props, never> {
   public render() {
     return (
       <BaseScreenComponent
-        headerTitle={I18n.t("messageDetails.headerTitle")}
+        headerTitle={I18n.t("navigation.messages")}
         goBack={this.goBack}
       >
         {this.renderCurrentState()}

--- a/ts/screens/preferences/ServiceDetailsScreen.tsx
+++ b/ts/screens/preferences/ServiceDetailsScreen.tsx
@@ -187,7 +187,7 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
     return (
       <BaseScreenComponent
         goBack={this.goBack}
-        headerTitle={I18n.t("serviceDetail.headerTitle")}
+        headerTitle={I18n.t("services.title")}
       >
         <Content>
           <Grid>

--- a/ts/screens/preferences/ServicesScreen.tsx
+++ b/ts/screens/preferences/ServicesScreen.tsx
@@ -112,6 +112,7 @@ class ServicesScreen extends React.Component<Props> {
   public render() {
     return (
       <TopScreenComponent
+        headerTitle={I18n.t("preferences.title")}
         title={I18n.t("services.title")}
         goBack={this.goBack}
         subtitle={I18n.t("services.subTitle")}

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -36,7 +36,10 @@ import AppHeader from "../../components/ui/AppHeader";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
 import { cardIcons } from "../../components/wallet/card/Logo";
 import I18n from "../../i18n";
-import { navigateToWalletConfirmCardDetails } from "../../store/actions/navigation";
+import {
+  navigateToWalletConfirmCardDetails,
+  navigateToWalletHome
+} from "../../store/actions/navigation";
 import { Dispatch } from "../../store/actions/types";
 import { addWalletCreditCardInit } from "../../store/actions/wallet/wallets";
 import { CreditCard } from "../../types/pagopa";
@@ -59,6 +62,7 @@ type NavigationParams = Readonly<{
 
 type ReduxMappedDispatchProps = Readonly<{
   addWalletCreditCardInit: () => void;
+  navigateToWalletHome: () => void;
   navigateToConfirmCardDetailsScreen: (card: CreditCard) => void;
 }>;
 
@@ -197,7 +201,9 @@ class AddCardScreen extends React.Component<Props, State> {
             <GoBackButton />
           </Left>
           <Body>
-            <Text>{I18n.t("wallet.addCardTitle")}</Text>
+            <Text numberOfLines={1} onPress={this.props.navigateToWalletHome}>
+              {I18n.t("wallet.addPaymentMethodTitle")}
+            </Text>
           </Body>
           <Right>
             <InstabugButtons />
@@ -339,6 +345,7 @@ const mapDispatchToProps = (
   dispatch: Dispatch,
   props: OwnProps
 ): ReduxMappedDispatchProps => ({
+  navigateToWalletHome: () => dispatch(navigateToWalletHome()),
   addWalletCreditCardInit: () => dispatch(addWalletCreditCardInit()),
   navigateToConfirmCardDetailsScreen: (creditCard: CreditCard) =>
     dispatch(

--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -38,7 +38,8 @@ import PaymentMethodsList from "../../components/wallet/PaymentMethodsList";
 import I18n from "../../i18n";
 import {
   navigateToPaymentTransactionSummaryScreen,
-  navigateToWalletAddCreditCard
+  navigateToWalletAddCreditCard,
+  navigateToWalletHome
 } from "../../store/actions/navigation";
 import { Dispatch } from "../../store/actions/types";
 import { UNKNOWN_RECIPIENT } from "../../types/unknown";
@@ -54,6 +55,7 @@ type NavigationParams = Readonly<{
 }>;
 
 type ReduxMappedDispatchProps = Readonly<{
+  navigateToWalletHome: () => void;
   navigateToTransactionSummary: () => void;
   navigateToAddCreditCard: () => void;
 }>;
@@ -72,11 +74,11 @@ class AddPaymentMethodScreen extends React.PureComponent<Props> {
             <GoBackButton />
           </Left>
           <Body>
-            {inPayment.isSome() ? (
-              <Text>{I18n.t("wallet.payWith.header")}</Text>
-            ) : (
-              <Text>{I18n.t("wallet.addPaymentMethodTitle")}</Text>
-            )}
+            <Text numberOfLines={1} onPress={this.props.navigateToWalletHome}>
+              {inPayment.isSome()
+                ? I18n.t("wallet.payWith.header")
+                : I18n.t("wallet.wallet")}
+            </Text>
           </Body>
           <Right>
             <InstabugButtons />
@@ -133,6 +135,7 @@ const mapDispatchToProps = (
   dispatch: Dispatch,
   props: OwnProps
 ): ReduxMappedDispatchProps => ({
+  navigateToWalletHome: () => dispatch(navigateToWalletHome()),
   navigateToTransactionSummary: () => {
     const maybeInPayment = props.navigation.getParam("inPayment");
     maybeInPayment.map(inPayment =>

--- a/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
+++ b/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
@@ -177,7 +177,9 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
             <GoBackButton />
           </Left>
           <Body>
-            <Text>{I18n.t("wallet.QRtoPay.byCameraTitle")}</Text>
+            <Text numberOfLines={1} onPress={this.props.navigateToWalletHome}>
+              {I18n.t("wallet.wallet")}
+            </Text>
           </Body>
           <Right>
             <InstabugButtons />


### PR DESCRIPTION
Ho reso le label presenti in testata per tornare alla pagina precedente cliccabili. Per questo, ho cambiato anche un po' di testi che facevano riferimento alla pagina corrente e non alla pagina a cui si tornava cliccandoci.

Non ho ancora approfondito la cosa per alcune pagine interne del wallet, ma volevo intanto creare una prima PR per capire se l'approccio è ok.