### PR TITLE
[#162164390,#163825403] Handle loadMessage requests with a pool of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Here is a still NOT complete table of the environment variables you can set:
 | NAME                           | DEFAULT |                                                                                                 |
 |--------------------------------|---------|-------------------------------------------------------------------------------------------------|
 | `DEBUG_BIOMETRIC_IDENTIFICATION` | NO      | If set to "YES" an Alert is rendered with the exact result code of the biometric identification. |
+| `TOT_MESSAGE_FETCH_WORKERS` | 5 | Number of workers to create for message detail fetching. This means that we will have at most a number of concurrent fetches (of the message detail) equal to the number of the workers.
 
 _Note: The sample configuration sets the app to interface with our test environment, on which we work continuously; therefore, it may occur that some features are not always available or are fully working._
 

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -29,6 +29,9 @@ const DEFAULT_FETCH_PAYMENT_MANAGER_LONG_TIMEOUT_MS = 10000;
 // default seconds of background activity before asking the PIN login
 const DEFAULT_BACKGROUND_ACTIVITY_TIMEOUT_S = 30;
 
+// Default number of workers to fetch message.
+const DEFAULT_TOT_MESSAGE_FETCH_WORKERS = 5;
+
 export const environment: string = Config.ENVIRONMENT;
 export const apiUrlPrefix: string = Config.API_URL_PREFIX;
 export const pagoPaApiUrlPrefix: string = Config.PAGOPA_API_URL_PREFIX;
@@ -64,6 +67,10 @@ export const backgroundActivityTimeout = t.Integer.decode(
 export const contentRepoUrl = NonEmptyString.decode(
   Config.CONTENT_REPO_URL
 ).getOrElse(DEFAULT_CONTENT_REPO_URL);
+
+export const totMessageFetchWorkers = t.Integer.decode(
+  Config.TOT_MESSAGE_FETCH_WORKERS
+).getOrElse(DEFAULT_TOT_MESSAGE_FETCH_WORKERS);
 
 export function isDevEnvironment() {
   return environment === "DEV";

--- a/ts/sagas/messages/__tests__/messages.test.ts
+++ b/ts/sagas/messages/__tests__/messages.test.ts
@@ -1,0 +1,115 @@
+import { left, right } from "fp-ts/lib/Either";
+import * as pot from "italia-ts-commons/lib/pot";
+import { testSaga } from "redux-saga-test-plan";
+
+import { CreatedMessageWithContent } from "../../../../definitions/backend/CreatedMessageWithContent";
+import { loadMessage as loadMessageAction } from "../../../store/actions/messages";
+import { toMessageWithContentPO } from "../../../types/MessageWithContentPO";
+import { fetchMessage, loadMessage } from "../messages";
+
+const testMessageId1 = "01BX9NSMKAAAS5PSP2FATZM6BQ";
+const testServiceId1 = "5a563817fcc896087002ea46c49a";
+
+const testMessageWithContent1: CreatedMessageWithContent = {
+  id: testMessageId1,
+  fiscal_code: "" as any,
+  created_at: new Date(),
+  content: {
+    markdown: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eget fringilla neque, laoreet volutpat elit. Nunc leo nisi, dignissim eget lobortis non, faucibus in augue." as any,
+    subject: "Lorem ipsum..." as any
+  },
+  sender_service_id: testServiceId1
+};
+
+describe("messages", () => {
+  describe("fetchMessage test plan", () => {
+    it("should call getMessage with the right parameters", () => {
+      const getMessage = jest.fn();
+      testSaga(fetchMessage, getMessage, { id: testMessageId1 })
+        .next()
+        .call(getMessage, { id: testMessageId1 });
+    });
+
+    it("should only return an empty error if the getMessage response is undefined (can't be decoded)", () => {
+      const getMessage = jest.fn();
+      testSaga(fetchMessage, getMessage, { id: testMessageId1 })
+        .next()
+        // Return undefined as getMessage response
+        .next(undefined)
+        .returns(left(Error()));
+    });
+
+    it("should only return the error if the getMessage response status is not 200", () => {
+      const getMessage = jest.fn();
+      const error = Error("Backend error");
+      testSaga(fetchMessage, getMessage, { id: testMessageId1 })
+        .next()
+        // Return 500 with an error message as getMessage response
+        .next({ status: 500, value: { title: error.message } })
+        .returns(left(error));
+    });
+
+    it("should return the message if the getMessage response status is 200", () => {
+      const getMessage = jest.fn();
+      testSaga(fetchMessage, getMessage, { id: testMessageId1 })
+        .next()
+        // Return 500 with an error message as getMessage response
+        .next({ status: 200, value: testMessageWithContent1 })
+        .returns(right(toMessageWithContentPO(testMessageWithContent1)));
+    });
+  });
+
+  describe("loadMessage test plan", () => {
+    it("should return the cached message if the message is in the cache", () => {
+      const getMessage = jest.fn();
+      testSaga(loadMessage, getMessage, { id: testMessageId1 })
+        .next()
+        .next({
+          message: pot.some(toMessageWithContentPO(testMessageWithContent1))
+        })
+        .returns(
+          right({
+            message: pot.some(toMessageWithContentPO(testMessageWithContent1))
+          })
+        );
+    });
+
+    it("should call fetchMessage with the right parameters", () => {
+      const getMessage = jest.fn();
+      testSaga(loadMessage, getMessage, { id: testMessageId1 })
+        .next()
+        .next()
+        .call(fetchMessage, getMessage, { id: testMessageId1 });
+    });
+
+    it("should put MESSAGE_LOAD_FAILURE and return the error if the message can't be fetched", () => {
+      const getMessage = jest.fn();
+      testSaga(loadMessage, getMessage, { id: testMessageId1 })
+        .next()
+        .next()
+        .call(fetchMessage, getMessage, { id: testMessageId1 })
+        // Return 200 with a valid message as getMessage response
+        .next(left(Error("Error")))
+        .put(loadMessageAction.failure({ id: testMessageId1, error: "Error" }))
+        .next()
+        .returns(left(Error("Error")));
+    });
+
+    it("should put MESSAGE_LOAD_SUCCESS and return the message if the message is fetched sucessfully", () => {
+      const getMessage = jest.fn();
+      testSaga(loadMessage, getMessage, { id: testMessageId1 })
+        .next()
+        .next()
+        .call(fetchMessage, getMessage, { id: testMessageId1 })
+        // Return 200 with a valid message as getMessage response
+        .next(right(toMessageWithContentPO(testMessageWithContent1)))
+        .put(
+          loadMessageAction.success(
+            toMessageWithContentPO(testMessageWithContent1)
+          )
+        )
+        .next()
+        .returns(right(toMessageWithContentPO(testMessageWithContent1)));
+    });
+  });
+});

--- a/ts/sagas/messages/messages.ts
+++ b/ts/sagas/messages/messages.ts
@@ -32,7 +32,7 @@ export function* loadMessage(
   > = yield select<GlobalState>(messageStateByIdSelector(meta.id));
 
   // If we already have the message in the store just return it
-  if (cachedMessage && pot.isSome(cachedMessage.message)) {
+  if (cachedMessage !== undefined && pot.isSome(cachedMessage.message)) {
     return right(cachedMessage);
   }
 
@@ -70,9 +70,11 @@ export function* fetchMessage(
       { id: meta.id }
     );
 
-    if (!response || response.status !== 200) {
+    if (response === undefined || response.status !== 200) {
       const error =
-        response && response.status === 500 ? response.value.title : undefined;
+        response !== undefined && response.status === 500
+          ? response.value.title
+          : undefined;
       // Return the error
       return left(Error(error));
     }

--- a/ts/sagas/messages/messages.ts
+++ b/ts/sagas/messages/messages.ts
@@ -26,15 +26,17 @@ export function* loadMessage(
   getMessage: TypeofApiCall<GetUserMessageT>,
   meta: CreatedMessageWithoutContent
 ): IterableIterator<Effect | Either<Error, MessageWithContentPO>> {
-  // If we already have the message in the store just return it
+  // Load the messages already in the redux store
   const cachedMessage: ReturnType<
     ReturnType<typeof messageStateByIdSelector>
   > = yield select<GlobalState>(messageStateByIdSelector(meta.id));
 
+  // If we already have the message in the store just return it
   if (cachedMessage && pot.isSome(cachedMessage.message)) {
     return right(cachedMessage);
   }
 
+  // Fetch the message from the Backend
   const maybeMessage: SagaCallReturnType<typeof fetchMessage> = yield call(
     fetchMessage,
     getMessage,

--- a/ts/sagas/messages/messages.ts
+++ b/ts/sagas/messages/messages.ts
@@ -1,0 +1,120 @@
+import { Either, left, right } from "fp-ts/lib/Either";
+import * as pot from "italia-ts-commons/lib/pot";
+import { TypeofApiCall } from "italia-ts-commons/lib/requests";
+import { buffers, Channel, channel } from "redux-saga";
+import { call, Effect, fork, put, select, take } from "redux-saga/effects";
+import { ActionType, getType } from "typesafe-actions";
+
+import { CreatedMessageWithoutContent } from "../../../definitions/backend/CreatedMessageWithoutContent";
+import { GetUserMessageT } from "../../../definitions/backend/requestTypes";
+import { loadMessage as loadMessageAction } from "../../store/actions/messages";
+import { messageStateByIdSelector } from "../../store/reducers/entities/messages/messagesById";
+import { GlobalState } from "../../store/reducers/types";
+import {
+  MessageWithContentPO,
+  toMessageWithContentPO
+} from "../../types/MessageWithContentPO";
+import { SagaCallReturnType } from "../../types/utils";
+
+const HANDLERS_NUMBER = 5;
+
+export function* watchMessageLoadRequest(
+  getMessage: TypeofApiCall<GetUserMessageT>
+) {
+  const requestsChannel: Channel<
+    ActionType<typeof loadMessageAction.request>
+  > = yield call(channel, buffers.expanding());
+
+  // Start handlers
+  // tslint:disable-next-line:no-let
+  for (let i = 0; i < HANDLERS_NUMBER; i++) {
+    yield fork(handleMessageLoadRequest, requestsChannel, getMessage);
+  }
+
+  while (true) {
+    // Take the loadMessage request action and put back in the channel
+    // to be processed by the handlers.
+    const action = yield take(getType(loadMessageAction.request));
+
+    //console.log("Dispatching loadMessage request to handlers");
+    requestsChannel.put(action);
+    //console.log("Dispatched loadMessage request to handlers");
+  }
+}
+
+function* handleMessageLoadRequest(
+  requestsChannel: Channel<ActionType<typeof loadMessageAction.request>>,
+  getMessage: TypeofApiCall<GetUserMessageT>
+) {
+  console.log("Handler for loadMessage request started");
+
+  // Infinite loog that wait and process loadMessage request from the channel
+  while (true) {
+    console.log("Waiting for loadMessage request");
+    const action: ActionType<typeof loadMessageAction.request> = yield take(
+      requestsChannel
+    );
+    console.log("Just arrived a loadMessage request");
+
+    const meta = action.payload;
+
+    yield call(loadMessage, getMessage, meta);
+  }
+}
+
+export function* loadMessage(
+  getMessage: TypeofApiCall<GetUserMessageT>,
+  meta: CreatedMessageWithoutContent
+): IterableIterator<Effect | Either<Error, MessageWithContentPO>> {
+  console.log("Loading message");
+
+  // If we already have the message in the store just return it
+  const cachedMessage: ReturnType<
+    ReturnType<typeof messageStateByIdSelector>
+  > = yield select<GlobalState>(messageStateByIdSelector(meta.id));
+
+  if (cachedMessage && pot.isSome(cachedMessage.message)) {
+    return right(cachedMessage);
+  }
+
+  const maybeMessage: SagaCallReturnType<typeof fetchMessage> = yield call(
+    fetchMessage,
+    getMessage,
+    meta
+  );
+
+  if (maybeMessage.isLeft()) {
+    yield put(
+      loadMessageAction.failure({
+        id: meta.id,
+        error: maybeMessage.value.message
+      })
+    );
+  } else {
+    yield put(loadMessageAction.success(maybeMessage.value));
+  }
+}
+
+export function* fetchMessage(
+  getMessage: TypeofApiCall<GetUserMessageT>,
+  meta: CreatedMessageWithoutContent
+): IterableIterator<Effect | Either<Error, MessageWithContentPO>> {
+  try {
+    const response: SagaCallReturnType<typeof getMessage> = yield call(
+      getMessage,
+      { id: meta.id }
+    );
+
+    if (!response || response.status !== 200) {
+      const error =
+        response && response.status === 500 ? response.value.title : undefined;
+      return left(Error(error));
+    }
+
+    // Trigger an action to store the new message (converted to plain object) and return it
+    const messageWithContentPO = toMessageWithContentPO(response.value);
+    return right(messageWithContentPO);
+  } catch (error) {
+    return left(error);
+  }
+}

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -44,6 +44,7 @@ import {
   startAndReturnIdentificationResult,
   watchIdentificationRequest
 } from "./identification";
+import { watchMessageLoadRequest } from "./messages/messages";
 import { updateInstallationSaga } from "./notifications";
 import { loadProfile, watchProfileUpsertRequestsSaga } from "./profile";
 import { authenticationSaga } from "./startup/authenticationSaga";
@@ -62,7 +63,6 @@ import { watchLogoutSaga } from "./startup/watchLogoutSaga";
 import { watchPinResetSaga } from "./startup/watchPinResetSaga";
 import { watchSessionExpiredSaga } from "./startup/watchSessionExpiredSaga";
 import { watchWalletSaga } from "./wallet";
-import { watchMessageLoadRequest } from "./messages/messages";
 
 /**
  * Handles the application startup and the main application logic loop
@@ -225,11 +225,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   );
 
   // Load messages when requested
-  yield fork(
-    watchMessagesLoadOrCancelSaga,
-    backendClient.getMessages,
-    backendClient.getMessage
-  );
+  yield fork(watchMessagesLoadOrCancelSaga, backendClient.getMessages);
 
   // Load messages when requested
   yield fork(watchMessageLoadRequest, backendClient.getMessage);

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -44,7 +44,6 @@ import {
   startAndReturnIdentificationResult,
   watchIdentificationRequest
 } from "./identification";
-import { watchMessageLoadRequest } from "./messages/messages";
 import { updateInstallationSaga } from "./notifications";
 import { loadProfile, watchProfileUpsertRequestsSaga } from "./profile";
 import { authenticationSaga } from "./startup/authenticationSaga";
@@ -60,6 +59,7 @@ import { watchApplicationActivitySaga } from "./startup/watchApplicationActivity
 import { watchMessagesLoadOrCancelSaga } from "./startup/watchLoadMessagesSaga";
 import { loadMessageWithRelationsSaga } from "./startup/watchLoadMessageWithRelationsSaga";
 import { watchLogoutSaga } from "./startup/watchLogoutSaga";
+import { watchMessageLoadSaga } from "./startup/watchMessageLoadSaga";
 import { watchPinResetSaga } from "./startup/watchPinResetSaga";
 import { watchSessionExpiredSaga } from "./startup/watchSessionExpiredSaga";
 import { watchWalletSaga } from "./wallet";
@@ -228,7 +228,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   yield fork(watchMessagesLoadOrCancelSaga, backendClient.getMessages);
 
   // Load messages when requested
-  yield fork(watchMessageLoadRequest, backendClient.getMessage);
+  yield fork(watchMessageLoadSaga, backendClient.getMessage);
 
   // Load message and related entities (ex. the sender service)
   yield takeEvery(

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -62,6 +62,7 @@ import { watchLogoutSaga } from "./startup/watchLogoutSaga";
 import { watchPinResetSaga } from "./startup/watchPinResetSaga";
 import { watchSessionExpiredSaga } from "./startup/watchSessionExpiredSaga";
 import { watchWalletSaga } from "./wallet";
+import { watchMessageLoadRequest } from "./messages/messages";
 
 /**
  * Handles the application startup and the main application logic loop
@@ -229,6 +230,9 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
     backendClient.getMessages,
     backendClient.getMessage
   );
+
+  // Load messages when requested
+  yield fork(watchMessageLoadRequest, backendClient.getMessage);
 
   // Load message and related entities (ex. the sender service)
   yield takeEvery(

--- a/ts/sagas/startup/__tests__/watchLoadMessages.test.ts
+++ b/ts/sagas/startup/__tests__/watchLoadMessages.test.ts
@@ -1,7 +1,6 @@
-import { left, right } from "fp-ts/lib/Either";
 import * as pot from "italia-ts-commons/lib/pot";
 import { testSaga } from "redux-saga-test-plan";
-import { call, put } from "redux-saga/effects";
+import { put } from "redux-saga/effects";
 
 import { CreatedMessageWithContent } from "../../../../definitions/backend/CreatedMessageWithContent";
 import { ServicePublic } from "../../../../definitions/backend/ServicePublic";
@@ -16,7 +15,7 @@ import {
 } from "../../../store/reducers/entities/messages/messagesById";
 import { servicesByIdSelector } from "../../../store/reducers/entities/services/servicesById";
 import { toMessageWithContentPO } from "../../../types/MessageWithContentPO";
-import { loadMessage, loadMessages } from "../../startup/watchLoadMessagesSaga";
+import { loadMessages } from "../../startup/watchLoadMessagesSaga";
 
 const testMessageId1 = "01BX9NSMKAAAS5PSP2FATZM6BQ";
 const testMessageId2 = "01CD4QN3Q2KS2T791PPMT2H9DM";
@@ -89,73 +88,7 @@ const testMessages = {
   page_size: 2
 };
 
-describe("messages", () => {
-  describe("loadMessage test plan", () => {
-    it("should call getMessage with the right parameters", () => {
-      const getMessage = jest.fn();
-      testSaga(loadMessage, getMessage, { id: testMessageId1 })
-        .next()
-        .next()
-        .put(loadMessageAction.request({ id: testMessageId1 } as any))
-        .next()
-        .call(getMessage, { id: testMessageId1 });
-    });
-
-    it("should only return an empty error if the getMessage response is undefined (can't be decoded)", () => {
-      const getMessage = jest.fn();
-      testSaga(loadMessage, getMessage, { id: testMessageId1 })
-        .next()
-        .next()
-        .put(loadMessageAction.request({ id: testMessageId1 } as any))
-        .next()
-        // Return undefined as getMessage response
-        .next(undefined)
-        .put(
-          loadMessageAction.failure({ id: testMessageId1, error: undefined })
-        )
-        .next()
-        .returns(left(Error()));
-    });
-
-    it("should only return the error if the getMessage response status is not 200", () => {
-      const getMessage = jest.fn();
-      const error = Error("Backend error");
-      testSaga(loadMessage, getMessage, { id: testMessageId1 })
-        .next()
-        .next()
-        .put(loadMessageAction.request({ id: testMessageId1 } as any))
-        .next()
-        // Return 500 with an error message as getMessage response
-        .next({ status: 500, value: { title: error.message } })
-        .put(
-          loadMessageAction.failure({
-            id: testMessageId1,
-            error: error.message
-          })
-        )
-        .next()
-        .returns(left(error));
-    });
-
-    it("should put MESSAGE_LOAD_SUCCESS and return the message if the getMessage response status is 200", () => {
-      const getMessage = jest.fn();
-      testSaga(loadMessage, getMessage, { id: testMessageId1 })
-        .next()
-        .next()
-        .put(loadMessageAction.request({ id: testMessageId1 } as any))
-        .next()
-        // Return 200 with a valid message as getMessage response
-        .next({ status: 200, value: testMessageWithContent1 })
-        .put(
-          loadMessageAction.success(
-            toMessageWithContentPO(testMessageWithContent1)
-          )
-        )
-        .next()
-        .returns(right(toMessageWithContentPO(testMessageWithContent1)));
-    });
-  });
-
+describe("watchLoadMessages", () => {
   describe("loadMessages test plan", () => {
     it("should put MESSAGES_LOAD_FAILURE with the Error it the getMessages response is an Error", () => {
       const getMessages = jest.fn();
@@ -198,8 +131,8 @@ describe("messages", () => {
         .all([put(loadService.request("5a563817fcc896087002ea46c49a"))])
         .next({ status: 200, value: testServicePublic })
         .all([
-          call(loadMessage, getMessage, testMessages.items[0] as any),
-          call(loadMessage, getMessage, testMessages.items[1] as any)
+          put(loadMessageAction.request(testMessages.items[0] as any)),
+          put(loadMessageAction.request(testMessages.items[1] as any))
         ]);
     });
 

--- a/ts/sagas/startup/watchLoadMessageWithRelationsSaga.ts
+++ b/ts/sagas/startup/watchLoadMessageWithRelationsSaga.ts
@@ -11,7 +11,7 @@ import { loadService } from "../../store/actions/services";
 import { serviceByIdSelector } from "../../store/reducers/entities/services/servicesById";
 import { GlobalState } from "../../store/reducers/types";
 import { SagaCallReturnType } from "../../types/utils";
-import { loadMessage } from "./watchLoadMessagesSaga";
+import { loadMessage } from "../messages/messages";
 
 /**
  * Load message with related entities (ex. the sender service).

--- a/ts/sagas/startup/watchLoadMessagesSaga.ts
+++ b/ts/sagas/startup/watchLoadMessagesSaga.ts
@@ -168,7 +168,7 @@ export function* loadMessages(
       // Fetch the messages detail in parallel
       // We don't need to store the results because the MESSAGE_LOAD_SUCCESS is already dispatched by each `loadMessage` action called,
       // in this way each message is stored as soon as the detail is fetched and the UI is more reactive.
-      yield all(pendingMessages.map(_ => call(loadMessage, getMessage, _)));
+      yield all(pendingMessages.map(_ => put(loadMessageAction.request(_))));
     }
   } catch (error) {
     // Dispatch failure action

--- a/ts/sagas/startup/watchLoadMessagesSaga.ts
+++ b/ts/sagas/startup/watchLoadMessagesSaga.ts
@@ -96,8 +96,7 @@ export function* loadMessage(
  * only the details of the messages and services not already in the redux store.
  */
 export function* loadMessages(
-  getMessages: TypeofApiCall<GetUserMessagesT>,
-  getMessage: TypeofApiCall<GetUserMessageT>
+  getMessages: TypeofApiCall<GetUserMessagesT>
 ): IterableIterator<Effect> {
   // We are using try...finally to manage task cancellation
   // @https://redux-saga.js.org/docs/advanced/TaskCancellation.html
@@ -188,8 +187,7 @@ export function* loadMessages(
  * More info @https://github.com/redux-saga/redux-saga/blob/master/docs/advanced/Concurrency.md#takelatest
  */
 export function* watchMessagesLoadOrCancelSaga(
-  getMessages: TypeofApiCall<GetUserMessagesT>,
-  getMessage: TypeofApiCall<GetUserMessageT>
+  getMessages: TypeofApiCall<GetUserMessagesT>
 ): IterableIterator<Effect> {
   // We store the latest task so we can also cancel it
   // tslint:disable-next-line:no-let
@@ -213,7 +211,7 @@ export function* watchMessagesLoadOrCancelSaga(
     // Otherwise it is a MESSAGES_LOAD_CANCEL and we just need to continue the loop
     if (isActionOf(loadMessagesAction.request, action)) {
       // Call the generator to load messages
-      lastTask = some(yield fork(loadMessages, getMessages, getMessage));
+      lastTask = some(yield fork(loadMessages, getMessages));
     }
   }
 }

--- a/ts/sagas/startup/watchLoadMessagesSaga.ts
+++ b/ts/sagas/startup/watchLoadMessagesSaga.ts
@@ -2,7 +2,6 @@
  * Generators to manage messages and related services.
  */
 
-import { Either, left, right } from "fp-ts/lib/Either";
 import { none, Option, some } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
 import { TypeofApiCall } from "italia-ts-commons/lib/requests";
@@ -20,11 +19,7 @@ import {
 } from "redux-saga/effects";
 import { ActionType, getType, isActionOf } from "typesafe-actions";
 
-import { CreatedMessageWithoutContent } from "../../../definitions/backend/CreatedMessageWithoutContent";
-import {
-  GetUserMessagesT,
-  GetUserMessageT
-} from "../../../definitions/backend/requestTypes";
+import { GetUserMessagesT } from "../../../definitions/backend/requestTypes";
 import { sessionExpired } from "../../store/actions/authentication";
 import {
   loadMessage as loadMessageAction,
@@ -32,63 +27,11 @@ import {
   loadMessagesCancel
 } from "../../store/actions/messages";
 import { loadService } from "../../store/actions/services";
-import {
-  messagesStateByIdSelector,
-  messageStateByIdSelector
-} from "../../store/reducers/entities/messages/messagesById";
+import { messagesStateByIdSelector } from "../../store/reducers/entities/messages/messagesById";
 import { servicesByIdSelector } from "../../store/reducers/entities/services/servicesById";
 import { GlobalState } from "../../store/reducers/types";
-import {
-  MessageWithContentPO,
-  toMessageWithContentPO
-} from "../../types/MessageWithContentPO";
 import { SagaCallReturnType } from "../../types/utils";
 import { uniqueItem } from "../../utils/enumerables";
-
-/**
- * A generator to load the message detail from the Backend
- *
- * @param {function} getMessage - The function that makes the Backend request
- * @param {string} meta - The id of the message to load
- * @returns {IterableIterator<Effect | Error | MessageWithContentPO>}
- */
-// FIXME: apparently the returned value doesn't get used, can we get rid of it?
-export function* loadMessage(
-  getMessage: TypeofApiCall<GetUserMessageT>,
-  meta: CreatedMessageWithoutContent
-): IterableIterator<Effect | Either<Error, MessageWithContentPO>> {
-  // If we already have the message in the store just return it
-  const cachedMessage: ReturnType<
-    ReturnType<typeof messageStateByIdSelector>
-  > = yield select<GlobalState>(messageStateByIdSelector(meta.id));
-  if (cachedMessage) {
-    return right(cachedMessage);
-  }
-
-  yield put(loadMessageAction.request(meta));
-
-  try {
-    const response: SagaCallReturnType<typeof getMessage> = yield call(
-      getMessage,
-      { id: meta.id }
-    );
-
-    if (!response || response.status !== 200) {
-      const error =
-        response && response.status === 500 ? response.value.title : undefined;
-      yield put(loadMessageAction.failure({ id: meta.id, error }));
-      return left(Error(error));
-    }
-
-    // Trigger an action to store the new message (converted to plain object) and return it
-    const messageWithContentPO = toMessageWithContentPO(response.value);
-    yield put(loadMessageAction.success(messageWithContentPO));
-    return right(messageWithContentPO);
-  } catch (error) {
-    yield put(loadMessageAction.failure(error));
-    return left(error);
-  }
-}
 
 /**
  * A generator to load messages from the Backend.

--- a/ts/sagas/startup/watchMessageLoadSaga.ts
+++ b/ts/sagas/startup/watchMessageLoadSaga.ts
@@ -1,0 +1,63 @@
+import { TypeofApiCall } from "italia-ts-commons/lib/requests";
+import { buffers, Channel, channel } from "redux-saga";
+import { call, fork, take } from "redux-saga/effects";
+import { ActionType, getType } from "typesafe-actions";
+
+import { GetUserMessageT } from "../../../definitions/backend/requestTypes";
+import { loadMessage as loadMessageAction } from "../../store/actions/messages";
+import { loadMessage } from "../messages/messages";
+
+// Here we set the number of handlers we want to create.
+// This means that we will have at most a number of concurrent
+// fetchs (of the message detail) equal to the number of the handlers.
+const NUMBER_OF_HANDLERS = 5;
+
+/**
+ * This generator listen for loadMessage.request actions and forward them
+ * to a poll of created handlers.
+ *
+ * @param getMessage API call to fetch the message detail
+ */
+export function* watchMessageLoadSaga(
+  getMessage: TypeofApiCall<GetUserMessageT>
+) {
+  // Create the channel used for the comunication with the handlers.
+  const requestsChannel: Channel<
+    ActionType<typeof loadMessageAction.request>
+  > = yield call(channel, buffers.expanding());
+
+  // Start the handlers
+  // tslint:disable-next-line:no-let
+  for (let i = 0; i < NUMBER_OF_HANDLERS; i++) {
+    yield fork(handleMessageLoadRequest, requestsChannel, getMessage);
+  }
+
+  while (true) {
+    // Take the loadMessage request action and put back in the channel
+    // to be processed by the handlers.
+    const action = yield take(getType(loadMessageAction.request));
+    requestsChannel.put(action);
+  }
+}
+
+/**
+ * A generator that listen for loadMessage.request from a channel and perform the
+ * handling.
+ *
+ * @param requestsChannel The channel where to take the loadMessage.request actions
+ * @param getMessage API call to fetch the message detail
+ */
+export function* handleMessageLoadRequest(
+  requestsChannel: Channel<ActionType<typeof loadMessageAction.request>>,
+  getMessage: TypeofApiCall<GetUserMessageT>
+) {
+  // Infinite loop that wait and process loadMessage requests from the channel
+  while (true) {
+    const action: ActionType<typeof loadMessageAction.request> = yield take(
+      requestsChannel
+    );
+
+    const meta = action.payload;
+    yield call(loadMessage, getMessage, meta);
+  }
+}

--- a/ts/sagas/startup/watchMessageLoadSaga.ts
+++ b/ts/sagas/startup/watchMessageLoadSaga.ts
@@ -18,7 +18,7 @@ export function* watchMessageLoadSaga(
   getMessage: TypeofApiCall<GetUserMessageT>
 ) {
   // Create the channel used for the communication with the handlers.
-  // The channel has a default initial size of 10.
+  // The channel has a buffer with initial size of 10 requests.
   const requestsChannel: Channel<
     ActionType<typeof loadMessageAction.request>
   > = yield call(channel, buffers.expanding());


### PR DESCRIPTION
The PR add a generator that listen for loadMessage.request actions and forward them to a pool of created handlers using a redux-saga channel. This means that we will have at most a number of concurrent fetches (of the message detail) equal to the number of the handlers, avoid the current problem of to many concurrent fetches.

Current version with **UNLIMITED** concurrent fetches (the device hangs and the offline message get rendered)
![unlimited](https://user-images.githubusercontent.com/30595520/53488371-5b1e7300-3a8e-11e9-9b90-d7092076b917.gif)

The new version with **LIMITED** concurrent fetch (no device hang and no offline message)
![limited](https://user-images.githubusercontent.com/30595520/53488410-725d6080-3a8e-11e9-97a8-93a14dd99275.gif)
