### PR TITLE
[#164595292] Fixed message CTA line height for iOS

### DIFF
--- a/ts/theme/components/Button.ts
+++ b/ts/theme/components/Button.ts
@@ -36,7 +36,16 @@ export default (): Theme => {
 
     ".xsmall": {
       height: variables.btnXSmallHeight,
-      "NativeBase.Text": { fontSize: variables.btnSmallFontSize }
+      "NativeBase.Text": {
+        fontSize: variables.btnSmallFontSize,
+        lineHeight: variables.btnXSmallLineHeight
+      },
+      "NativeBase.Icon": {
+        fontSize: variables.btnSmallFontSize
+      },
+      "UIComponent.IconFont": {
+        fontSize: variables.btnSmallFontSize
+      }
     },
 
     ".small": {

--- a/ts/theme/variables.ts
+++ b/ts/theme/variables.ts
@@ -21,6 +21,7 @@ const customVariables = Object.assign(materialVariables, {
   btnHeight: 48,
   btnFontSize: 16,
   btnXSmallHeight: 32,
+  btnXSmallLineHeight: 22,
   btnSmallHeight: 39,
   btnSmallFontSize: 16,
   get btnLightTextColor(): ThemeSimpleValue {


### PR DESCRIPTION
This PR aims to fix message CTA line height for iOS

Screen from iPhone 6s
![Simulator Screen Shot - iPhone 6s - 2019-03-13 at 12 54 01](https://user-images.githubusercontent.com/39746618/54277093-24b51d80-458f-11e9-877c-e232ee09cfc8.png)
