### PR TITLE
[#164595292] fix line height for small message CTA labels in iOS

### DIFF
--- a/ts/theme/components/Button.ts
+++ b/ts/theme/components/Button.ts
@@ -36,7 +36,16 @@ export default (): Theme => {
 
     ".xsmall": {
       height: variables.btnXSmallHeight,
-      "NativeBase.Text": { fontSize: variables.btnSmallFontSize }
+      "NativeBase.Text": {
+        fontSize: variables.btnSmallFontSize,
+        lineHeight: variables.btnXSmallLineHeight
+      },
+      "NativeBase.Icon": {
+        fontSize: variables.btnSmallFontSize
+      },
+      "UIComponent.IconFont": {
+        fontSize: variables.btnSmallFontSize
+      }
     },
 
     ".small": {

--- a/ts/theme/components/Button.ts
+++ b/ts/theme/components/Button.ts
@@ -41,10 +41,12 @@ export default (): Theme => {
         lineHeight: variables.btnXSmallLineHeight
       },
       "NativeBase.Icon": {
-        fontSize: variables.btnSmallFontSize
+        fontSize: variables.btnSmallFontSize,
+        paddingTop: 1
       },
       "UIComponent.IconFont": {
-        fontSize: variables.btnSmallFontSize
+        fontSize: variables.btnSmallFontSize,
+        paddingTop: 1
       }
     },
 

--- a/ts/theme/variables.ts
+++ b/ts/theme/variables.ts
@@ -21,7 +21,7 @@ const customVariables = Object.assign(materialVariables, {
   btnHeight: 48,
   btnFontSize: 16,
   btnXSmallHeight: 32,
-  btnXSmallLineHeight: 22,
+  btnXSmallLineHeight: 20,
   btnSmallHeight: 39,
   btnSmallFontSize: 16,
   get btnLightTextColor(): ThemeSimpleValue {

--- a/ts/theme/variables.ts
+++ b/ts/theme/variables.ts
@@ -21,6 +21,7 @@ const customVariables = Object.assign(materialVariables, {
   btnHeight: 48,
   btnFontSize: 16,
   btnXSmallHeight: 32,
+  btnXSmallLineHeight: 22,
   btnSmallHeight: 39,
   btnSmallFontSize: 16,
   get btnLightTextColor(): ThemeSimpleValue {


### PR DESCRIPTION
This PR aims to fix line height in messages CTA 

iOS (iPhone X)
![Simulator Screen Shot - iPhone X - 2019-03-14 at 16 03 22](https://user-images.githubusercontent.com/39746618/54367491-bd709980-4672-11e9-83ad-44c99b57a65d.png)

=============================================
Android
![Schermata 2019-03-14 alle 16 01 58](https://user-images.githubusercontent.com/39746618/54367548-d5e0b400-4672-11e9-9535-983357b1e304.png)
