### PR TITLE
[#164351434] Remove card data on background

### DIFF
--- a/patches/@types/react-native-text-input-mask+0.7.2.patch
+++ b/patches/@types/react-native-text-input-mask+0.7.2.patch
@@ -1,0 +1,11 @@
+patch-package
+--- a/node_modules/@types/react-native-text-input-mask/index.d.ts
++++ b/node_modules/@types/react-native-text-input-mask/index.d.ts
+@@ -223,4 +223,6 @@ export interface TextInputMaskProps extends ReactNative.ViewProps, ReactNative.T
+     value?: string;
+ }
+ 
+-export default class TextInputMask extends React.Component<TextInputMaskProps> { }
++export default class TextInputMask extends React.Component<TextInputMaskProps> {
++  clear: () => void;
++}

--- a/patches/react-native-text-input-mask+0.8.0.patch
+++ b/patches/react-native-text-input-mask+0.8.0.patch
@@ -1,0 +1,44 @@
+patch-package
+--- a/node_modules/react-native-text-input-mask/index.js
++++ b/node_modules/react-native-text-input-mask/index.js
+@@ -10,6 +10,7 @@ import {
+ const mask = NativeModules.RNTextInputMask.mask
+ const unmask = NativeModules.RNTextInputMask.unmask
+ const setMask = NativeModules.RNTextInputMask.setMask
++const setText = NativeModules.RNTextInputMask.setText
+ export { mask, unmask, setMask }
+ 
+ export default class TextInputMask extends Component {
+@@ -68,4 +69,13 @@ export default class TextInputMask extends Component {
+       }}
+     />);
+   }
++
++  clear() {
++    if (Platform.OS === 'ios') {
++      setText(findNodeHandle(this.input), '');
++    } else {
++      this.input.setNativeProps({ text: '' });
++    }
++    this.props.onChangeText('');
++  }
+ }
+--- a/node_modules/react-native-text-input-mask/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
++++ b/node_modules/react-native-text-input-mask/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
+@@ -59,6 +59,16 @@ RCT_EXPORT_METHOD(setMask:(nonnull NSNumber *)reactNode mask:(NSString *)mask) {
+     }];
+ }
+ 
++RCT_EXPORT_METHOD(setText:(nonnull NSNumber *)reactNode text:(NSString *)text){
++    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTSinglelineTextInputView *> *viewRegistry ) {
++        dispatch_async(dispatch_get_main_queue(), ^{
++            RCTSinglelineTextInputView *view = viewRegistry[reactNode];
++            UIView<RCTBackedTextInputViewProtocol>  *textView = [view backedTextInputView];
++            [textView setAttributedText:[[NSAttributedString alloc] initWithString:text]];
++        });
++    }];
++}
++
+ - (void)textField:(RCTUITextField *)textField didFillMandatoryCharacters:(BOOL)complete didExtractValue:(NSString *)value
+ {
+     [self.bridge.eventDispatcher sendTextEventWithType:RCTTextEventTypeChange

--- a/ts/@types/native-base-types.d.ts
+++ b/ts/@types/native-base-types.d.ts
@@ -19,12 +19,18 @@ declare module "native-base-shoutem-theme" {
     props: P
   ) => ReadonlyArray<string>;
 
-  export function connectStyle(
+  /**
+   * The connectStyle function do not use forwardRef.
+   * To get a ref to the wrapped component you have to use _root.
+   * 
+   * RT = _root Type
+   */
+  export function connectStyle<RT = {}>(
     componentStyleName: string,
     componentStyle = {},
     mapPropsToStyleNames: MapPropsToStyleNames,
     options?: IConnectStyleOptions
-  ): <C, O = C>(c: C) => O;
+  ): <C, O = C>(c: C) => O & { _root: RT };
 }
 
 declare module "native-base/src/utils/mapPropsToStyleNames" {

--- a/ts/@types/native-base-types.d.ts
+++ b/ts/@types/native-base-types.d.ts
@@ -20,7 +20,7 @@ declare module "native-base-shoutem-theme" {
   ) => ReadonlyArray<string>;
 
   /**
-   * The connectStyle function do not use forwardRef.
+   * The connectStyle function does not use forwardRef.
    * To get a ref to the wrapped component you have to use _root.
    * 
    * RT = _root Type

--- a/ts/components/ui/MaskedInput.tsx
+++ b/ts/components/ui/MaskedInput.tsx
@@ -2,7 +2,7 @@ import { connectStyle } from "native-base-shoutem-theme";
 import mapPropsToStyleNames from "native-base/src/utils/mapPropsToStyleNames";
 import TextInputMask from "react-native-text-input-mask";
 
-export default connectStyle(
+export default connectStyle<TextInputMask>(
   "UIComponent.MaskedInput",
   {},
   mapPropsToStyleNames

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -8,6 +8,8 @@ import { entries, range, size } from "lodash";
 import { Content, Item, Text, View } from "native-base";
 import * as React from "react";
 import {
+  AppState,
+  AppStateStatus,
   FlatList,
   Image,
   Keyboard,
@@ -82,6 +84,13 @@ const EMPTY_CARD_PAN = "";
 const EMPTY_CARD_EXPIRATION_DATE = "";
 const EMPTY_CARD_SECURITY_CODE = "";
 
+const INITIAL_STATE: State = {
+  pan: none,
+  expirationDate: none,
+  securityCode: none,
+  holder: none
+};
+
 function getCardFromState(state: State): Option<CreditCard> {
   const { pan, expirationDate, securityCode, holder } = state;
   if (
@@ -126,12 +135,15 @@ function getCardFromState(state: State): Option<CreditCard> {
 class AddCardScreen extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = {
-      pan: none,
-      expirationDate: none,
-      securityCode: none,
-      holder: none
-    };
+    this.state = INITIAL_STATE;
+  }
+
+  public componentDidMount() {
+    AppState.addEventListener("change", this.handleAppStateChange);
+  }
+
+  public componentWillUnmount() {
+    AppState.removeEventListener("change", this.handleAppStateChange);
   }
 
   public render(): React.ReactNode {
@@ -311,6 +323,12 @@ class AddCardScreen extends React.Component<Props, State> {
       </BaseScreenComponent>
     );
   }
+
+  private handleAppStateChange = (nextAppStateStatus: AppStateStatus) => {
+    if (nextAppStateStatus !== "active") {
+      this.setState(INITIAL_STATE);
+    }
+  };
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, props: OwnProps) => ({

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -239,11 +239,10 @@ class AddCardScreen extends React.Component<Props, State> {
                 keyboardType: "numeric",
                 maxLength: 23,
                 mask: "[0000] [0000] [0000] [0000] [999]",
-                onChangeText: (_, value) => {
+                onChangeText: (_, value) =>
                   this.setState({
                     pan: value && value !== EMPTY_CARD_PAN ? some(value) : none
-                  });
-                }
+                  })
               }}
             />
 

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -144,6 +144,12 @@ class AddCardScreen extends React.Component<Props, State> {
   }
 
   public componentDidMount() {
+    // The AppState change is also stored and notified by our redux store but
+    // we are using the event lister directly because we want to clear the
+    // input fileds as soon as possible before going in background (remember
+    // Android does not have a "inactive" intermediate state).
+    // This prevent the input fields to be cleared only when the application
+    // is back to active state.
     AppState.addEventListener("change", this.handleAppStateChange);
   }
 

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -233,10 +233,11 @@ class AddCardScreen extends React.Component<Props, State> {
                 keyboardType: "numeric",
                 maxLength: 23,
                 mask: "[0000] [0000] [0000] [0000] [999]",
-                onChangeText: (_, value) =>
+                onChangeText: (_, value) => {
                   this.setState({
-                    pan: value !== EMPTY_CARD_PAN ? some(value) : none
-                  })
+                    pan: value && value !== EMPTY_CARD_PAN ? some(value) : none
+                  });
+                }
               }}
             />
 
@@ -260,7 +261,7 @@ class AddCardScreen extends React.Component<Props, State> {
                     onChangeText: (_, value) =>
                       this.setState({
                         expirationDate:
-                          value !== EMPTY_CARD_EXPIRATION_DATE
+                          value && value !== EMPTY_CARD_EXPIRATION_DATE
                             ? some(value)
                             : none
                       })
@@ -286,7 +287,7 @@ class AddCardScreen extends React.Component<Props, State> {
                     onChangeText: (_, value) =>
                       this.setState({
                         securityCode:
-                          value !== EMPTY_CARD_SECURITY_CODE
+                          value && value !== EMPTY_CARD_SECURITY_CODE
                             ? some(value)
                             : none
                       })
@@ -334,10 +335,8 @@ class AddCardScreen extends React.Component<Props, State> {
 
   private handleAppStateChange = (nextAppStateStatus: AppStateStatus) => {
     if (nextAppStateStatus !== "active") {
-      // Clear all the inputs
-      this.setState(INITIAL_STATE);
       // For a bug in the `react-native-text-input-mask` library we have to
-      // reset the TextInputMask components value calling the clear function,
+      // reset the TextInputMask components value calling the clear function.
       if (this.panRef.current) {
         this.panRef.current._root.clear();
       }
@@ -347,6 +346,7 @@ class AddCardScreen extends React.Component<Props, State> {
       if (this.securityCodeRef.current) {
         this.securityCodeRef.current._root.clear();
       }
+      this.setState(INITIAL_STATE);
     }
   };
 }

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -17,6 +17,7 @@ import {
   StyleSheet
 } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
+import TextInputMask from "react-native-text-input-mask";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 
@@ -133,6 +134,7 @@ function getCardFromState(state: State): Option<CreditCard> {
 }
 
 class AddCardScreen extends React.Component<Props, State> {
+  private panRef: React.RefObject<TextInputMask> = React.createRef();
   constructor(props: Props) {
     super(props);
     this.state = INITIAL_STATE;
@@ -222,6 +224,7 @@ class AddCardScreen extends React.Component<Props, State> {
               label={I18n.t("wallet.dummyCard.labels.pan")}
               icon="io-carta"
               inputMaskProps={{
+                ref: this.panRef,
                 value: this.state.pan.getOrElse(EMPTY_CARD_PAN),
                 placeholder: I18n.t("wallet.dummyCard.values.pan"),
                 keyboardType: "numeric",
@@ -326,6 +329,9 @@ class AddCardScreen extends React.Component<Props, State> {
 
   private handleAppStateChange = (nextAppStateStatus: AppStateStatus) => {
     if (nextAppStateStatus !== "active") {
+      if (this.panRef.current) {
+        this.panRef.current.clear();
+      }
       this.setState(INITIAL_STATE);
     }
   };

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -145,11 +145,13 @@ class AddCardScreen extends React.Component<Props, State> {
 
   public componentDidMount() {
     // The AppState change is also stored and notified by our redux store but
-    // we are using the event lister directly because we want to clear the
-    // input fileds as soon as possible before going in background (remember
-    // Android does not have a "inactive" intermediate state).
-    // This prevent the input fields to be cleared only when the application
-    // is back to active state.
+    // we are using the event listener directly because we want to clear the
+    // input fields as soon as possible before going to background (remember
+    // Android does not have an "inactive" intermediate state).
+    // If we wait the AppState change from the store sometimes when we reopen
+    // the app the input values are still present and after some milliseconds
+    // get cleared.
+
     AppState.addEventListener("change", this.handleAppStateChange);
   }
 
@@ -340,8 +342,8 @@ class AddCardScreen extends React.Component<Props, State> {
 
   private handleAppStateChange = (nextAppStateStatus: AppStateStatus) => {
     if (nextAppStateStatus !== "active") {
-      // For a bug in the `react-native-text-input-mask` library we have to
-      // reset the TextInputMask components value calling the clear function.
+      // Due to a bug in the `react-native-text-input-mask` library we have to
+      // reset the value in the TextInputMask components by calling the "clear" method.
       if (this.panRef.current) {
         this.panRef.current._root.clear();
       }

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -17,7 +17,6 @@ import {
   StyleSheet
 } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
-import TextInputMask from "react-native-text-input-mask";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 
@@ -25,6 +24,7 @@ import { PaymentRequestsGetResponse } from "../../../definitions/backend/Payment
 
 import { LabelledItem } from "../../components/LabelledItem";
 import { WalletStyles } from "../../components/styles/wallet";
+import MaskedInput from "../../components/ui/MaskedInput";
 
 import BaseScreenComponent from "../../components/screens/BaseScreenComponent";
 
@@ -134,7 +134,10 @@ function getCardFromState(state: State): Option<CreditCard> {
 }
 
 class AddCardScreen extends React.Component<Props, State> {
-  private panRef: React.RefObject<TextInputMask> = React.createRef();
+  private panRef = React.createRef<typeof MaskedInput>();
+  private expirationDateRef = React.createRef<typeof MaskedInput>();
+  private securityCodeRef = React.createRef<typeof MaskedInput>();
+
   constructor(props: Props) {
     super(props);
     this.state = INITIAL_STATE;
@@ -245,6 +248,7 @@ class AddCardScreen extends React.Component<Props, State> {
                   label={I18n.t("wallet.dummyCard.labels.expirationDate")}
                   icon="io-calendario"
                   inputMaskProps={{
+                    ref: this.expirationDateRef,
                     value: this.state.expirationDate.getOrElse(
                       EMPTY_CARD_EXPIRATION_DATE
                     ),
@@ -270,6 +274,7 @@ class AddCardScreen extends React.Component<Props, State> {
                   label={I18n.t("wallet.dummyCard.labels.securityCode")}
                   icon="io-lucchetto"
                   inputMaskProps={{
+                    ref: this.securityCodeRef,
                     value: this.state.securityCode.getOrElse(
                       EMPTY_CARD_SECURITY_CODE
                     ),
@@ -329,10 +334,19 @@ class AddCardScreen extends React.Component<Props, State> {
 
   private handleAppStateChange = (nextAppStateStatus: AppStateStatus) => {
     if (nextAppStateStatus !== "active") {
-      if (this.panRef.current) {
-        this.panRef.current.clear();
-      }
+      // Clear all the inputs
       this.setState(INITIAL_STATE);
+      // For a bug in the `react-native-text-input-mask` library we have to
+      // reset the TextInputMask components value calling the clear function,
+      if (this.panRef.current) {
+        this.panRef.current._root.clear();
+      }
+      if (this.expirationDateRef.current) {
+        this.expirationDateRef.current._root.clear();
+      }
+      if (this.securityCodeRef.current) {
+        this.securityCodeRef.current._root.clear();
+      }
     }
   };
 }


### PR DESCRIPTION

A bug in `react-native-text-input-mask` prevent to clear the TextInputMask component value using setState so a patch is needed.

https://github.com/react-native-community/react-native-text-input-mask/issues/68
https://github.com/react-native-community/react-native-text-input-mask/pull/61

 
![Cardadata](https://user-images.githubusercontent.com/30595520/54543647-5159a280-499e-11e9-8e89-50594b0c798d.gif)