### PR TITLE
[#164896887] Clear user data at first run after install on iOS devices

### DIFF
--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -71,7 +71,8 @@ const rootPersistConfig: PersistConfig = {
     "profile",
     "entities",
     "debug",
-    "persistedPreferences"
+    "persistedPreferences",
+    "installation"
   ]
 };
 

--- a/ts/sagas/installation.ts
+++ b/ts/sagas/installation.ts
@@ -4,7 +4,6 @@
 import { call, Effect, put, select } from "redux-saga/effects";
 
 import { sessionInvalid } from "../store/actions/authentication";
-import { previousInstallationDataDeleteSuccess } from "../store/actions/installation";
 import { isFirstRunAfterInstallSelector } from "../store/reducers/installation";
 import { GlobalState } from "../store/reducers/types";
 import { deletePin } from "../utils/keychain";
@@ -26,7 +25,5 @@ export function* previousInstallationDataDeleteSaga(): IterableIterator<
     yield call(deletePin);
     // invalidate the session
     yield put(sessionInvalid());
-
-    yield put(previousInstallationDataDeleteSuccess());
   }
 }

--- a/ts/sagas/installation.ts
+++ b/ts/sagas/installation.ts
@@ -1,0 +1,32 @@
+/**
+ * A saga to manage notifications
+ */
+import { call, Effect, put, select } from "redux-saga/effects";
+
+import { sessionInvalid } from "../store/actions/authentication";
+import { previousInstallationDataDeleteSuccess } from "../store/actions/installation";
+import { isFirstRunAfterInstallSelector } from "../store/reducers/installation";
+import { GlobalState } from "../store/reducers/types";
+import { deletePin } from "../utils/keychain";
+
+/**
+ * This generator function removes user data from previous application
+ * installation
+ */
+export function* previousInstallationDataDeleteSaga(): IterableIterator<
+  Effect
+> {
+  const isFirstRunAfterInstall: ReturnType<
+    typeof isFirstRunAfterInstallSelector
+  > = yield select<GlobalState>(isFirstRunAfterInstallSelector);
+
+  if (isFirstRunAfterInstall) {
+    // Delete the current PIN from the Keychain
+    // tslint:disable-next-line:saga-yield-return-type
+    yield call(deletePin);
+    // invalidate the session
+    yield put(sessionInvalid());
+
+    yield put(previousInstallationDataDeleteSuccess());
+  }
+}

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -20,6 +20,7 @@ import { IdentityProvider } from "../models/IdentityProvider";
 import AppNavigator from "../navigation/AppNavigator";
 import { startApplicationInitialization } from "../store/actions/application";
 import { sessionExpired } from "../store/actions/authentication";
+import { previousInstallationDataDeleteSuccess } from "../store/actions/installation";
 import { loadMessageWithRelations } from "../store/actions/messages";
 import {
   navigateToMainNavigatorAction,
@@ -79,6 +80,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   if (Platform.OS === "ios") {
     yield call(previousInstallationDataDeleteSaga);
   }
+  yield put(previousInstallationDataDeleteSuccess());
 
   // Reset the profile cached in redux: at each startup we want to load a fresh
   // user profile.

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -1,4 +1,5 @@
 import { isNone, Option } from "fp-ts/lib/Option";
+import { Platform } from "react-native";
 import { NavigationActions, NavigationState } from "react-navigation";
 import { Effect } from "redux-saga";
 import {
@@ -44,6 +45,7 @@ import {
   startAndReturnIdentificationResult,
   watchIdentificationRequest
 } from "./identification";
+import { previousInstallationDataDeleteSaga } from "./installation";
 import { updateInstallationSaga } from "./notifications";
 import { loadProfile, watchProfileUpsertRequestsSaga } from "./profile";
 import { authenticationSaga } from "./startup/authenticationSaga";
@@ -69,6 +71,15 @@ import { watchWalletSaga } from "./wallet";
  */
 // tslint:disable-next-line:cognitive-complexity no-big-function
 function* initializeApplicationSaga(): IterableIterator<Effect> {
+  // FIXME: Workaround for iOS only. Below iOS version 12.3 Keychain is not
+  //        cleared between one installation and another, so it is needed to
+  //        manually clear previous installation user info in order to force
+  //        the user to choose PIN and run through onboarding every new
+  //        installation.
+  if (Platform.OS === "ios") {
+    yield call(previousInstallationDataDeleteSaga);
+  }
+
   // Reset the profile cached in redux: at each startup we want to load a fresh
   // user profile.
   yield put(resetProfileState());

--- a/ts/store/actions/installation.ts
+++ b/ts/store/actions/installation.ts
@@ -1,0 +1,13 @@
+/**
+ * Action type related to the installation of the app.
+ */
+
+import { ActionType, createStandardAction } from "typesafe-actions";
+
+export const previousInstallationDataDeleteSuccess = createStandardAction(
+  "PREV_INSTALLATION_DATA_DELETE_SUCCESS"
+)();
+
+export type InstallationActions = ActionType<
+  typeof previousInstallationDataDeleteSuccess
+>;

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -18,6 +18,7 @@ import { ContentActions } from "./content";
 import { DebugActions } from "./debug";
 import { DeepLinkActions } from "./deepLink";
 import { IdentificationActions } from "./identification";
+import { InstallationActions } from "./installation";
 import { MessagesActions } from "./messages";
 import { NavigationActions } from "./navigation";
 import { NavigationHistoryActions } from "./navigationHistory";
@@ -49,6 +50,7 @@ export type Action =
   | ContentActions
   | NavigationHistoryActions
   | IdentificationActions
+  | InstallationActions
   | DebugActions
   | CalendarEventsActions;
 

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -17,6 +17,7 @@ import { debugReducer } from "./debug";
 import deepLinkReducer from "./deepLink";
 import entitiesReducer from "./entities";
 import identificationReducer from "./identification";
+import installationReducer from "./installation";
 import navigationReducer from "./navigation";
 import navigationHistoryReducer from "./navigationHistory";
 import notificationsReducer from "./notifications";
@@ -55,6 +56,7 @@ const appReducer: Reducer<GlobalState, Action> = combineReducers<
   network: networkReducer,
   nav: navigationReducer,
   deepLink: deepLinkReducer,
+  installation: installationReducer,
   wallet: walletReducer,
   backendInfo: backendInfoReducer,
   content: contentReducer,

--- a/ts/store/reducers/installation.ts
+++ b/ts/store/reducers/installation.ts
@@ -1,0 +1,38 @@
+/**
+ * A reducer for the Installation state.
+ * @flow
+ */
+import { getType } from "typesafe-actions";
+
+import { previousInstallationDataDeleteSuccess } from "../actions/installation";
+import { Action } from "../actions/types";
+import { GlobalState } from "./types";
+
+export type InstallationState = Readonly<{
+  isFirstRunAfterInstall: boolean;
+}>;
+
+const INITIAL_STATE: InstallationState = {
+  isFirstRunAfterInstall: true
+};
+
+// Selectors
+export const isFirstRunAfterInstallSelector = (state: GlobalState): boolean =>
+  state.installation.isFirstRunAfterInstall;
+
+const reducer = (
+  state: InstallationState = INITIAL_STATE,
+  action: Action
+): InstallationState => {
+  switch (action.type) {
+    case getType(previousInstallationDataDeleteSuccess):
+      return {
+        isFirstRunAfterInstall: false
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/ts/store/reducers/types.ts
+++ b/ts/store/reducers/types.ts
@@ -10,6 +10,7 @@ import { DebugState } from "./debug";
 import { DeepLinkState } from "./deepLink";
 import { EntitiesState } from "./entities";
 import { IdentificationState } from "./identification";
+import { InstallationState } from "./installation";
 import { NavigationHistoryState } from "./navigationHistory";
 import { NotificationsState } from "./notifications";
 import { OnboardingState } from "./onboarding";
@@ -40,6 +41,7 @@ export type GlobalState = Readonly<{
   content: ContentState;
   navigationHistory: NavigationHistoryState;
   identification: IdentificationState;
+  installation: InstallationState;
   debug: DebugState;
 }>;
 


### PR DESCRIPTION
This PR aims to clear data at first run of the app on iOS devices. 

This has to be considered as a workaround for devices having iOS 12.3 or below, because keychains is not cleared between two consequent installations of the same app, in those versions.

![record](https://user-images.githubusercontent.com/39746618/55224715-67bef400-5211-11e9-9d85-a59c87358ed9.gif)
