### PR TITLE
[#161952466] Fixed truncated offline label

### DIFF
--- a/ts/components/ConnectionBar.tsx
+++ b/ts/components/ConnectionBar.tsx
@@ -33,6 +33,7 @@ const styles = StyleSheet.create({
     marginRight: customVariables.fontSizeBase / 2
   },
   text: {
+    fontFamily: "RobotoMono-Regular",
     textAlign: "center",
     color: customVariables.colorWhite,
     fontWeight: "bold"

--- a/ts/components/ConnectionBar.tsx
+++ b/ts/components/ConnectionBar.tsx
@@ -1,6 +1,7 @@
 import color from "color";
+import { Text } from "native-base";
 import * as React from "react";
-import { Platform, StyleSheet, Text, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
 import { connect } from "react-redux";
 
 import I18n from "../i18n";
@@ -33,7 +34,6 @@ const styles = StyleSheet.create({
     marginRight: customVariables.fontSizeBase / 2
   },
   text: {
-    fontFamily: "RobotoMono-Regular",
     textAlign: "center",
     color: customVariables.colorWhite,
     fontWeight: "bold"


### PR DESCRIPTION
The problem of the truncated label occurs only on some devices that use certain system fonts such as the OnePlus or OPPO phones. Forcing the Text to use the RobotoMono-Regular font (already present in the assets folder) the problem is solved.