### PR TITLE
[#165008942] service detail screen markdown loading

### DIFF
--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -4,6 +4,7 @@
 import { fromNullable } from "fp-ts/lib/Option";
 import React from "react";
 import {
+  ActivityIndicator,
   InteractionManager,
   LayoutAnimation,
   Platform,
@@ -21,7 +22,6 @@ import { connect } from "react-redux";
 import { ReduxProps } from "../../../store/actions/types";
 import customVariables from "../../../theme/variables";
 import { remarkProcessor } from "../../../utils/markdown";
-import ActivityIndicator from "../ActivityIndicator";
 import { handleLinkMessage } from "./handlers/link";
 import { NOTIFY_BODY_HEIGHT_SCRIPT, NOTIFY_LINK_CLICK_SCRIPT } from "./script";
 import { WebViewMessage } from "./types";
@@ -212,8 +212,14 @@ class Markdown extends React.PureComponent<Props, State> {
 
     return (
       <React.Fragment>
+        <ActivityIndicator
+          size="large"
+          color={customVariables.brandPrimary}
+          animating={
+            html === undefined || (html !== "" && htmlBodyHeight === 0)
+          }
+        />
         {/* Hide the WebView until we have the htmlBodyHeight */}
-        {!html && <ActivityIndicator />}
         {html && (
           <ScrollView nestedScrollEnabled={false} style={containerStyle}>
             <View style={containerStyle}>

--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -206,40 +206,35 @@ class Markdown extends React.PureComponent<Props, State> {
   public render() {
     const { webViewStyle } = this.props;
     const { html, htmlBodyHeight } = this.state;
+    const containerStyle: ViewStyle = {
+      height: htmlBodyHeight
+    };
 
-    if (html) {
-      // Hide the WebView until we have the htmlBodyHeight
-      const containerStyle: ViewStyle =
-        htmlBodyHeight === 0
-          ? {
-              height: 0
-            }
-          : {
-              height: htmlBodyHeight
-            };
-
-      return (
-        <ScrollView nestedScrollEnabled={false} style={containerStyle}>
-          <View style={containerStyle}>
-            <WebView
-              ref={this.webViewRef}
-              scrollEnabled={false}
-              overScrollMode={"never"}
-              style={webViewStyle}
-              originWhitelist={["*"]}
-              source={{ html, baseUrl: "" }}
-              javaScriptEnabled={true}
-              injectedJavaScript={INJECTED_JAVASCRIPT}
-              onLoadEnd={this.handleLoadEnd}
-              onMessage={this.handleWebViewMessage}
-              showsVerticalScrollIndicator={false}
-            />
-          </View>
-        </ScrollView>
-      );
-    }
-
-    return <ActivityIndicator />;
+    return (
+      <React.Fragment>
+        {/* Hide the WebView until we have the htmlBodyHeight */}
+        {!html && <ActivityIndicator />}
+        {html && (
+          <ScrollView nestedScrollEnabled={false} style={containerStyle}>
+            <View style={containerStyle}>
+              <WebView
+                ref={this.webViewRef}
+                scrollEnabled={false}
+                overScrollMode={"never"}
+                style={webViewStyle}
+                originWhitelist={["*"]}
+                source={{ html, baseUrl: "" }}
+                javaScriptEnabled={true}
+                injectedJavaScript={INJECTED_JAVASCRIPT}
+                onLoadEnd={this.handleLoadEnd}
+                onMessage={this.handleWebViewMessage}
+                showsVerticalScrollIndicator={false}
+              />
+            </View>
+          </ScrollView>
+        )}
+      </React.Fragment>
+    );
   }
 
   // When the injected html is loaded inject the script to notify the height

--- a/ts/screens/preferences/ServiceDetailsScreen.tsx
+++ b/ts/screens/preferences/ServiceDetailsScreen.tsx
@@ -324,7 +324,7 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
               </Col>
             </Row>
             <View spacer={true} large={true} />
-            {description && <Markdown animated={false}>{description}</Markdown>}
+            {description && <Markdown animated={true}>{description}</Markdown>}
             {description && <View spacer={true} large={true} />}
             {tos_url && (
               <TouchableOpacity

--- a/ts/screens/preferences/ServiceDetailsScreen.tsx
+++ b/ts/screens/preferences/ServiceDetailsScreen.tsx
@@ -324,7 +324,7 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
               </Col>
             </Row>
             <View spacer={true} large={true} />
-            {description && <Markdown animated={true}>{description}</Markdown>}
+            {description && <Markdown animated={false}>{description}</Markdown>}
             {description && <View spacer={true} large={true} />}
             {tos_url && (
               <TouchableOpacity


### PR DESCRIPTION
This PR aims to fix the case when markdown content is rendered during the ease-out animation of the Activity indicator as shown here

<img width="428" alt="screen" src="https://user-images.githubusercontent.com/39746618/56133858-a84a9b80-5f8d-11e9-85a7-7bc3e0ae9102.png">
