### PR TITLE
[#161417464] Whole card component handle touch event, moved from footer and refactored

### DIFF
--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -95,7 +95,7 @@ export default class CardComponent extends React.Component<Props> {
     }
   };
 
-  private handleOnFooterPress = () => {
+  private handleOnCardPress = () => {
     if (
       (this.props.type === "Full" || this.props.type === "Picking") &&
       this.props.mainAction
@@ -242,7 +242,6 @@ export default class CardComponent extends React.Component<Props> {
         style={[styles.footerButton, buttonStyle]}
         block={true}
         iconRight={true}
-        onPress={this.handleOnFooterPress}
       >
         <Text style={footerTextStyle}>{text}</Text>
         <IconFont
@@ -263,6 +262,7 @@ export default class CardComponent extends React.Component<Props> {
     return (
       <View
         style={[styles.card, hasFlatBottom ? styles.flatBottom : undefined]}
+        onTouchStart={this.handleOnCardPress}
       >
         <View style={styles.cardInner}>
           <View style={styles.columns}>


### PR DESCRIPTION
<img width="220" alt="Screenshot 2019-04-15 at 12 16 27" src="https://user-images.githubusercontent.com/4312710/56148840-77795f00-5fab-11e9-970a-dbb5f21ef1c0.png">

The whole card area is available for selection.