### PR TITLE
[#165274563] Fix credit card rendering on samsung

### DIFF
--- a/ts/components/wallet/card/CardComponent.style.ts
+++ b/ts/components/wallet/card/CardComponent.style.ts
@@ -24,6 +24,12 @@ export default StyleSheet.create({
     paddingRight: 16,
     paddingTop: 22
   },
+
+  cardNumber: {
+    flexDirection: "row",
+    justifyContent: "flex-start"
+  },
+
   columns: {
     flexDirection: "row",
     justifyContent: "space-between"

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -266,14 +266,14 @@ export default class CardComponent extends React.Component<Props> {
       >
         <View style={styles.cardInner}>
           <View style={styles.columns}>
-            <Text
-              style={[
-                CreditCardStyles.textStyle,
-                CreditCardStyles.largeTextStyle
-              ]}
-            >
-              {`${HIDDEN_CREDITCARD_NUMBERS}${wallet.creditCard.pan.slice(-4)}`}
-            </Text>
+            <View style={[styles.cardNumber]}>
+              <Text style={[CreditCardStyles.smallTextStyle]}>
+                {`${HIDDEN_CREDITCARD_NUMBERS}`}
+              </Text>
+              <Text style={[CreditCardStyles.largeTextStyle]}>
+                {`${wallet.creditCard.pan.slice(-4)}`}
+              </Text>
+            </View>
 
             <View style={styles.topRightCornerContainer}>
               {this.renderTopRightCorner()}


### PR DESCRIPTION
This pr should fix a bug on the credic card rendering. It had been tested on s5 device. It affects the fontsize of the hidden numbers only, reducing it from the larger to the smaller font size.

**Before the commit:**

<img width="239" alt="immagine" src="https://user-images.githubusercontent.com/38431762/56356922-6febcd00-61da-11e9-89be-c89b9146eb67.png">

<img width="242" alt="immagine" src="https://user-images.githubusercontent.com/38431762/56357017-b50fff00-61da-11e9-8b3e-050884c3a5d6.png">

**After the commit:**

<img width="235" alt="immagine" src="https://user-images.githubusercontent.com/38431762/56356859-4a5ec380-61da-11e9-9611-b45bda8b6669.png">


<img width="291" alt="immagine" src="https://user-images.githubusercontent.com/38431762/56356786-1a172500-61da-11e9-9d5f-9fad87224108.png">


**Here the rendering on ios after the commit:**

<img width="384" alt="immagine" src="https://user-images.githubusercontent.com/38431762/56356816-3024e580-61da-11e9-8dab-51a6f844674d.png">



