### PR TITLE
[#165415250] Change language settings alert text in preferences screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -538,6 +538,9 @@ preferences:
   unavailable:
     title: This setting is set up on your SPID profile
     message: IO inherits temporarily this setting from your SPID profile. You can edit it from your SPID profile in your identity provider, then you will have to log in this app again
+  language: 
+    title: This setting is set up in system preferences
+    message: IO inherits language from the operating system of this device
 biometric_recognition:
   title: Biometric recognition
   subTitle: Enable or disable biometric recognition

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -550,6 +550,9 @@ preferences:
   unavailable:
     title: Questa preferenza è impostata nel tuo profilo SPID
     message: Per ora IO eredita questo dato dai tuoi attributi SPID. Puoi modificarlo nell profilo SPID del tuo identity provider, e poi dovrai nuovamente loggarti nell'app
+  language:
+    title: Questa preferenza è impostata nelle preferenze di sistema
+    message: IO eredita la lingua dal sistema operativo del tuo dispositivo
 biometric_recognition:
   title: Riconoscimento biometrico
   subTitle: Attiva o disattiva il riconoscimento biometrico

--- a/ts/screens/preferences/PreferencesScreen.tsx
+++ b/ts/screens/preferences/PreferencesScreen.tsx
@@ -35,6 +35,12 @@ const unavailableAlert = () =>
     I18n.t("preferences.unavailable.message")
   );
 
+const languageAlert = () =>
+  Alert.alert(
+    I18n.t("preferences.language.title"),
+    I18n.t("preferences.language.message")
+  );
+
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
 }>;
@@ -206,7 +212,7 @@ class PreferencesScreen extends React.Component<Props, State> {
                 valuePreview={profileData.spid_mobile_phone}
               />
             </ListItem>
-            <ListItem onPress={unavailableAlert}>
+            <ListItem onPress={languageAlert}>
               <PreferenceItem
                 kind="value"
                 title={I18n.t("preferences.list.language")}


### PR DESCRIPTION
This PR aims to change language copy because the previous was not accurate.

![screen](https://user-images.githubusercontent.com/39746618/56650825-1f67ea00-6688-11e9-9df0-d3a480229c2a.png)
