### PR TITLE
[#165410496] Add ellipsis to QR code button long label

### DIFF
--- a/ts/components/ui/FooterWithButtons.tsx
+++ b/ts/components/ui/FooterWithButtons.tsx
@@ -68,7 +68,7 @@ export default class FooterWithButtons extends React.Component<Props, never> {
               : styles.button
           }
         >
-          <Text>{rightButtonTitle}</Text>
+          <Text numberOfLines={1}>{rightButtonTitle}</Text>
         </Button>
       </React.Fragment>
     );


### PR DESCRIPTION
This PR aims to fix UI when footer right button has a too long label. This bug shows up in QR code read screen.

![Simulator Screen Shot - iPhone 5s - 2019-04-24 at 12 20 13](https://user-images.githubusercontent.com/39746618/56652297-555a9d80-668b-11e9-90c1-4c80f8dd99ff.png)
