### PR TITLE
[#165387562] Fix TouchID popup-trigger controls

### DIFF
--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -214,7 +214,9 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         this.props.identificationState.kind === "started")
     ) {
       this.maybeTriggerFingerprintRequest({
-        updateBiometrySupportProp: this.props.appState === "active"
+        updateBiometrySupportProp:
+          prevProps.appState === "background" &&
+          this.props.appState === "active"
       });
     }
   }

--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -215,8 +215,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
     ) {
       this.maybeTriggerFingerprintRequest({
         updateBiometrySupportProp:
-          prevProps.appState === "background" &&
-          this.props.appState === "active"
+          prevProps.appState !== "active" && this.props.appState === "active"
       });
     }
   }


### PR DESCRIPTION
This PR aims to fix TouchID popup-trigger controls by specifying more compelling conditions.

Expected behaviour:
IC: app up and running on any page of choice.
1. CIT presses home button sending the app to background
2. CIT presses side screen-off button
3. CIT presses button of 2. again setting the screen on and unlocks the device
4. IS shows icons in the background
5. CIT taps the app and opens it
6. IS shows the latest page visited (IS DOES NOT prompt the TouchID alert over IO app page)
END

IC: initial conditions . 
IS: the system (the device) of the user . 
CIT: the user . 

![screen](https://user-images.githubusercontent.com/39746618/57153576-f5749d00-6dd6-11e9-810d-e729d087454b.gif)
