### PR TITLE
[#165631660] add a link to PEC detail in service screen

### DIFF
--- a/ts/screens/preferences/ServiceDetailsScreen.tsx
+++ b/ts/screens/preferences/ServiceDetailsScreen.tsx
@@ -450,7 +450,10 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
               renderInformationRow("EMail", email, () =>
                 Linking.openURL(`mailto:${email}`).then(() => 0, () => 0)
               )}
-            {pec && renderInformationRow("PEC", pec)}
+            {pec &&
+              renderInformationRow("PEC", pec, () =>
+                Linking.openURL(`mailto:${pec}`).then(() => 0, () => 0)
+              )}
             {web_url &&
               renderInformationRow("Web", web_url, () =>
                 Linking.openURL(web_url).then(() => 0, () => 0)


### PR DESCRIPTION
This PR aims to add a link to PEC detail in service screen

![screen](https://user-images.githubusercontent.com/39746618/57542626-7f31e680-7352-11e9-9142-1ec80b1f999c.gif)
