### PR TITLE
[#165407029] Fix ViewPagerAndroid Warning message

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -61,7 +61,7 @@ PODS:
     - React
   - RNFS (2.13.3):
     - React
-  - RNGestureHandler (1.0.16):
+  - RNGestureHandler (1.2.1):
     - React
   - RNI18n (2.0.15):
     - React
@@ -161,7 +161,7 @@ SPEC CHECKSUMS:
   ReactNativePermissions: b64e084dff6a5cad51587d38c306f09246246384
   RNDeviceInfo: e7c5fcde13d40e161d8a27f6c5dc69c638936002
   RNFS: c9bbde46b0d59619f8e7b735991c60e0f73d22c1
-  RNGestureHandler: 0438a761e8f29be3b809f9e7e43014f3aba4d7a6
+  RNGestureHandler: aea90f0ad8e35fec23438db6fc3ad79be58bb734
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8
   RNKeychain: 1a121521011702409f5a1009eb8a1effa81000f3
   RNSVG: 4501a5e968f1eb962f5481b0da53dfb59260e9b6

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-native-exception-handler": "2.10.0",
     "react-native-flag-secure-android": "git://github.com/teamdigitale/react-native-flag-secure-android.git#7afcf2a418b945f976a4f0e7a72e89301253c795",
     "react-native-fs": "^2.13.3",
-    "react-native-gesture-handler": "^1.0.16",
+    "react-native-gesture-handler": "^1.2.1",
     "react-native-i18n": "^2.0.15",
     "react-native-keychain": "^3.1.1",
     "react-native-mixpanel": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7360,7 +7360,16 @@ react-native-fs@^2.13.3:
     base-64 "^0.1.0"
     utf8 "^2.1.1"
 
-react-native-gesture-handler@^1.0.16, react-native-gesture-handler@~1.0.14:
+react-native-gesture-handler@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.2.1.tgz#9c48fb1ab13d29cece24bbb77b1e847eebf27a2b"
+  integrity sha512-c1+L72Vjc/bwHKcIJ8a2/88SW9l3/axcAIpg3zB1qTzwdCxHZJeQn6d58cQXHPepxFBbgfTCo60B7SipSfo+zw==
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+    invariant "^2.2.2"
+    prop-types "^15.5.10"
+
+react-native-gesture-handler@~1.0.14:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.16.tgz#bee54981575e581857c2298e133ce2ffac240a3e"
   integrity sha512-KhUjDaiGKESfVa/lywuYfdZ2pomPC4q/dRQo18qlSZuRxEiOCxzSo9Q1TV7JK3PpyyMEXpsU04kYSSVypWiSxg==


### PR DESCRIPTION
> Warning: ViewPagerAndroid has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-community/viewpager' instead of 'react-native'. See https://github.com/react-native-community/react-native-viewpager


The problem is caused by an old version of the "react-native-gesture-handler" library, updating to version 1.2.1 the Warning no longer appears.