### PR TITLE
[#162156637]  Make data format depending from locales on transaction details

### DIFF
--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -36,6 +36,7 @@ import variables from "../../theme/variables";
 import { Transaction } from "../../types/pagopa";
 import { cleanTransactionDescription } from "../../utils/payment";
 import { centsToAmount, formatNumberAmount } from "../../utils/stringBuilder";
+import { formatDateAsLocal } from "./../../utils/dates";
 
 type NavigationParams = Readonly<{
   isPaymentCompletedTransaction: boolean;
@@ -221,7 +222,7 @@ class TransactionDetailsScreen extends React.Component<Props> {
             )}
             {this.labelValueRow(
               I18n.t("wallet.date"),
-              transaction.created.toLocaleDateString()
+              formatDateAsLocal(transaction.created, true)
             )}
             {this.labelValueRow(
               I18n.t("wallet.time"),


### PR DESCRIPTION
This pr use the existing function formatDateAsLocal to present data with a format depending on the selected locale.

Here an example of the effect when it is mocked a transaction with creation date (transaction.create) equal to new Date(2018,10,30,13,12,22,30).

English:
<img width="307" alt="immagine" src="https://user-images.githubusercontent.com/38431762/57923387-75543a00-78a2-11e9-9f0d-792322eb62ef.png">

Italian:
<img width="314" alt="immagine" src="https://user-images.githubusercontent.com/38431762/57923463-acc2e680-78a2-11e9-8c7f-84dd4f7b6e01.png">


