### PR TITLE
[#162156628] Changed Total amount column label

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -406,6 +406,7 @@ wallet:
     submitBugText: If you can't solve the problem, please let us know with the ladybug icon at the top right. Thank you!
   transactionDetails: Transaction details
   total: Total
+  amount: Amount
   payAmount: Amount to pay
   transactionFee: Transaction fee
   why: Why?

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -415,6 +415,7 @@ wallet:
     amount: Importo (€)
     proceed: Procedi con il pagamento
   total: Totale
+  amount: Importo
   payAmount: Importo da pagare
   transactionFee: Costo operazione
   why: Perché?

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -29,7 +29,7 @@ import H5 from "../ui/H5";
 
 type Props = Readonly<{
   title: string;
-  totalAmount: string;
+  amount: string;
   transactions: pot.Pot<ReadonlyArray<Transaction>, Error>;
   navigateToTransactionDetails: (transaction: Transaction) => void;
   ListEmptyComponent?: React.ReactNode;
@@ -150,7 +150,7 @@ export default class TransactionsList extends React.Component<Props> {
             <H5 style={styles.brandDarkGray}>
               {I18n.t("wallet.latestTransactions")}
             </H5>
-            <Text>{I18n.t("wallet.total")}</Text>
+            <Text>{I18n.t("wallet.amount")}</Text>
           </View>
         </View>
 

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -122,7 +122,7 @@ class TransactionsScreen extends React.Component<Props> {
       >
         <TransactionsList
           title={I18n.t("wallet.transactions")}
-          totalAmount={I18n.t("wallet.total")}
+          amount={I18n.t("wallet.amount")}
           transactions={this.props.transactions}
           navigateToTransactionDetails={
             this.props.navigateToTransactionDetailsScreen

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -267,7 +267,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
     return (
       <TransactionsList
         title={I18n.t("wallet.latestTransactions")}
-        totalAmount={I18n.t("wallet.total")}
+        amount={I18n.t("wallet.amount")}
         transactions={potTransactions}
         navigateToTransactionDetails={
           this.props.navigateToTransactionDetailsScreen


### PR DESCRIPTION
The label of the Total amount column in the Wallet Home has been changed to Amount since it doesn't include the commission fees.

![device-2019-06-12-123343](https://user-images.githubusercontent.com/8174240/59344429-5ebcc980-8d0e-11e9-9b53-3db98fdbc9de.png)
