### PR TITLE
[#166639738] Inherit dynamic subheader height form the component itself

### DIFF
--- a/ts/components/screens/AnimatedScreenContent.tsx
+++ b/ts/components/screens/AnimatedScreenContent.tsx
@@ -75,12 +75,11 @@ export default class AnimatedScreenContent extends React.Component<
       .scrollTo({ y: 0, animated: false });
   };
 
-  // TODO: define how to properly get the header height
   private headerHeight: number =
     Platform.OS === "ios"
       ? isIphoneX()
-        ? customVariables.appHeaderHeight + 42 + 6
-        : customVariables.appHeaderHeight + 18 + 6
+        ? customVariables.appHeaderHeight + 42
+        : customVariables.appHeaderHeight + 18
       : StatusBar.currentHeight
         ? customVariables.appHeaderHeight + StatusBar.currentHeight
         : customVariables.appHeaderHeight;

--- a/ts/components/screens/AnimatedScreenContent.tsx
+++ b/ts/components/screens/AnimatedScreenContent.tsx
@@ -80,9 +80,7 @@ export default class AnimatedScreenContent extends React.Component<
       ? isIphoneX()
         ? customVariables.appHeaderHeight + 42
         : customVariables.appHeaderHeight + 18
-      : StatusBar.currentHeight
-        ? customVariables.appHeaderHeight + StatusBar.currentHeight
-        : customVariables.appHeaderHeight;
+      : customVariables.appHeaderHeight;
 
   public render(): React.ReactNode {
     const { topContentHeight, animationOffset, contentStyle } = this.props;
@@ -100,8 +98,8 @@ export default class AnimatedScreenContent extends React.Component<
         topContentHeight + animationOffset
       ],
       outputRange: [
-        -this.state.dynamicSubHeaderHeight,
-        -this.state.dynamicSubHeaderHeight,
+        -this.state.dynamicSubHeaderHeight - this.headerHeight,
+        -this.state.dynamicSubHeaderHeight ,
         0
       ],
       extrapolate: "clamp"
@@ -134,6 +132,7 @@ export default class AnimatedScreenContent extends React.Component<
 
         <Animated.View
           onLayout={(event: LayoutChangeEvent) =>
+            this.state.dynamicSubHeaderHeight === 0 &&
             this.setState({
               dynamicSubHeaderHeight: event.nativeEvent.layout.height
             })

--- a/ts/components/screens/AnimatedScreenContent.tsx
+++ b/ts/components/screens/AnimatedScreenContent.tsx
@@ -9,7 +9,6 @@ import {
   Animated,
   LayoutChangeEvent,
   Platform,
-  StatusBar,
   StyleProp,
   StyleSheet,
   ViewStyle

--- a/ts/components/screens/AnimatedScreenContent.tsx
+++ b/ts/components/screens/AnimatedScreenContent.tsx
@@ -7,6 +7,7 @@ import { View } from "native-base";
 import * as React from "react";
 import {
   Animated,
+  LayoutChangeEvent,
   Platform,
   StatusBar,
   StyleProp,
@@ -22,7 +23,6 @@ import { ScreenContentHeader } from "./ScreenContentHeader";
 
 type OwnProps = Readonly<{
   dynamicSubHeader: React.ReactNode;
-  dynamicSubHeaderHeight: number;
   topContentHeight: number;
   animationOffset: number;
   hideHeader?: boolean;
@@ -33,10 +33,12 @@ type Props = OwnProps & ComponentProps<typeof ScreenContentHeader>;
 
 type State = Readonly<{
   scrollY: Animated.Value;
+  dynamicSubHeaderHeight: number;
 }>;
 
 const INITIAL_STATE = {
-  scrollY: new Animated.Value(0)
+  scrollY: new Animated.Value(0),
+  dynamicSubHeaderHeight: 0
 };
 
 const styles = StyleSheet.create({
@@ -84,12 +86,7 @@ export default class AnimatedScreenContent extends React.Component<
         : customVariables.appHeaderHeight;
 
   public render(): React.ReactNode {
-    const {
-      dynamicSubHeaderHeight,
-      topContentHeight,
-      animationOffset,
-      contentStyle
-    } = this.props;
+    const { topContentHeight, animationOffset, contentStyle } = this.props;
 
     /**
      * The object referred as subHeader will be animated at scroll so that
@@ -103,7 +100,11 @@ export default class AnimatedScreenContent extends React.Component<
         topContentHeight - animationOffset,
         topContentHeight + animationOffset
       ],
-      outputRange: [-dynamicSubHeaderHeight, -dynamicSubHeaderHeight, 0],
+      outputRange: [
+        -this.state.dynamicSubHeaderHeight,
+        -this.state.dynamicSubHeaderHeight,
+        0
+      ],
       extrapolate: "clamp"
     });
 
@@ -133,6 +134,11 @@ export default class AnimatedScreenContent extends React.Component<
         </Animated.ScrollView>
 
         <Animated.View
+          onLayout={(event: LayoutChangeEvent) =>
+            this.setState({
+              dynamicSubHeaderHeight: event.nativeEvent.layout.height
+            })
+          }
           style={[
             styles.level1,
             styles.animatedSubHeader,

--- a/ts/components/screens/AnimatedScreenContent.tsx
+++ b/ts/components/screens/AnimatedScreenContent.tsx
@@ -99,7 +99,7 @@ export default class AnimatedScreenContent extends React.Component<
       ],
       outputRange: [
         -this.state.dynamicSubHeaderHeight - this.headerHeight,
-        -this.state.dynamicSubHeaderHeight ,
+        -this.state.dynamicSubHeaderHeight - this.headerHeight,
         0
       ],
       extrapolate: "clamp"

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -110,9 +110,6 @@ export default class WalletLayout extends React.Component<Props> {
             dynamicSubHeader={this.dynamicSubHeader()}
             topContentHeight={250}
             animationOffset={40}
-            dynamicSubHeaderHeight={
-              customVariables.h5LineHeight + 2 * customVariables.spacerWidth
-            }
           >
             {this.screenContent()}
           </AnimatedScreenContent>


### PR DESCRIPTION
This pr introduces the usage of the onLayout attribute to measure the height of the dynamic sub-header into the AnimatedScreenContent component.