### PR TITLE
[#166694691] Fix opacity in the loading screen of payment summary

### DIFF
--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -323,7 +323,7 @@ const mapStateToProps = (state: GlobalState) => {
     error,
     isLoading,
     loadingCaption,
-    loadingOpacity: 0.95,
+    loadingOpacity: 0.98,
     potVerifica: verifica,
     maybeFavoriteWallet,
     hasWallets


### PR DESCRIPTION
Increased the opacity for the payment summary screen

Before:
![before](https://user-images.githubusercontent.com/8174240/59495379-71aad780-8e8f-11e9-921c-2917043249e2.png)

Now:
![now](https://user-images.githubusercontent.com/8174240/59495391-78d1e580-8e8f-11e9-9710-fc0fab753e87.png)

