### PR TITLE
[#166789157] Fix header title and tab bar position for android devices

### DIFF
--- a/ts/components/screens/ScreenContentHeader.tsx
+++ b/ts/components/screens/ScreenContentHeader.tsx
@@ -1,6 +1,6 @@
 import { H1, Text, View } from "native-base";
 import * as React from "react";
-import { ImageSourcePropType, StyleSheet } from "react-native";
+import { ImageSourcePropType, Platform, StyleSheet } from "react-native";
 import { getStatusBarHeight } from "react-native-iphone-x-helper";
 
 import variables from "../../theme/variables";
@@ -27,7 +27,9 @@ const styles = StyleSheet.create({
   },
   fixedPosition: {
     position: "absolute",
-    top: variables.appHeaderHeight + getStatusBarHeight(true),
+    top:
+      variables.appHeaderHeight +
+      (Platform.OS === "ios" ? getStatusBarHeight(true) : 0),
     right: 0,
     left: 0
   },

--- a/ts/components/screens/ScreenContentHeader.tsx
+++ b/ts/components/screens/ScreenContentHeader.tsx
@@ -1,7 +1,7 @@
 import { H1, Text, View } from "native-base";
 import * as React from "react";
 import { ImageSourcePropType, Platform, StyleSheet } from "react-native";
-import { getStatusBarHeight } from "react-native-iphone-x-helper";
+import { isIphoneX } from "react-native-iphone-x-helper";
 
 import variables from "../../theme/variables";
 import ScreenHeader from "../ScreenHeader";
@@ -28,8 +28,11 @@ const styles = StyleSheet.create({
   fixedPosition: {
     position: "absolute",
     top:
-      variables.appHeaderHeight +
-      (Platform.OS === "ios" ? getStatusBarHeight(true) : 0),
+      Platform.OS === "ios"
+        ? isIphoneX()
+          ? variables.appHeaderHeight + 42
+          : variables.appHeaderHeight + 18
+        : variables.appHeaderHeight,
     right: 0,
     left: 0
   },

--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -2,7 +2,7 @@ import * as pot from "italia-ts-commons/lib/pot";
 import { Tab, TabHeading, Tabs, Text } from "native-base";
 import * as React from "react";
 import { Animated, Platform, StyleSheet } from "react-native";
-import { getStatusBarHeight } from "react-native-iphone-x-helper";
+import { getStatusBarHeight, isIphoneX } from "react-native-iphone-x-helper";
 
 import { NavigationScreenProps } from "react-navigation";
 import { connect } from "react-redux";
@@ -44,7 +44,9 @@ type State = {
 const SCROLL_RANGE_FOR_ANIMATION =
   customVariables.appHeaderHeight +
   (Platform.OS === "ios"
-    ? getStatusBarHeight(true)
+    ? isIphoneX()
+      ? 18
+      : getStatusBarHeight(true)
     : customVariables.spacerHeight);
 
 const styles = StyleSheet.create({

--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -1,7 +1,9 @@
 import * as pot from "italia-ts-commons/lib/pot";
 import { Tab, TabHeading, Tabs, Text } from "native-base";
 import * as React from "react";
-import { Animated, StyleSheet } from "react-native";
+import { Animated, Platform, StyleSheet } from "react-native";
+import { getStatusBarHeight } from "react-native-iphone-x-helper";
+
 import { NavigationScreenProps } from "react-navigation";
 import { connect } from "react-redux";
 import MessagesArchive from "../../components/messages/MessagesArchive";
@@ -39,7 +41,11 @@ type State = {
 };
 
 // Scroll range is directly influenced by floating header height
-const SCROLL_RANGE_FOR_ANIMATION = 72;
+const SCROLL_RANGE_FOR_ANIMATION =
+  customVariables.appHeaderHeight +
+  (Platform.OS === "ios"
+    ? getStatusBarHeight(true)
+    : customVariables.spacerHeight);
 
 const styles = StyleSheet.create({
   tabBarContainer: {
@@ -233,7 +239,6 @@ class MessagesHomeScreen extends React.Component<Props, State> {
                     ],
                     outputRange: [
                       0,
-
                       SCROLL_RANGE_FOR_ANIMATION * 0.75,
                       SCROLL_RANGE_FOR_ANIMATION
                     ],
@@ -311,7 +316,6 @@ class MessagesHomeScreen extends React.Component<Props, State> {
                     ],
                     outputRange: [
                       0,
-
                       SCROLL_RANGE_FOR_ANIMATION * 0.75,
                       SCROLL_RANGE_FOR_ANIMATION
                     ],


### PR DESCRIPTION
This PR aims to fix header title and tab bar position for android devices

Android
<img width="425" alt="Schermata 2019-06-19 alle 15 38 32" src="https://user-images.githubusercontent.com/39746618/59774047-0b6aee00-92af-11e9-805b-611a8db65372.png">

iPhone 8
![Simulator Screen Shot - iPhone 8 - 2019-06-19 at 16 06 22](https://user-images.githubusercontent.com/39746618/59774056-11f96580-92af-11e9-9b4e-87b169583a37.png)

iPhone X
![Simulator Screen Shot - iPhone X - 2019-06-19 at 16 08 53](https://user-images.githubusercontent.com/39746618/59774073-19b90a00-92af-11e9-8463-0590e032ae2e.png)

