### PR TITLE
[#167008321] Fix pagoPa specs check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,10 +498,10 @@ workflows:
   nightly-pagopa-specs-check:
       triggers:
         - schedule:
-            cron: "53 15 * * *"
+            cron: "0 03 * * *"
             filters:
               branches:
                 only:
-                  - 167008321-fix-pagoPa-specs-check
+                  - master
       jobs:
         - pagopa_specs_diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,10 +498,10 @@ workflows:
   nightly-pagopa-specs-check:
       triggers:
         - schedule:
-            cron: "0 03 * * *"
+            cron: "48 15 * * *"
             filters:
               branches:
                 only:
-                  - master
+                  - 167008321-fix-pagoPa-specs-check
       jobs:
         - pagopa_specs_diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,7 +498,7 @@ workflows:
   nightly-pagopa-specs-check:
       triggers:
         - schedule:
-            cron: "48 15 * * *"
+            cron: "53 15 * * *"
             filters:
               branches:
                 only:

--- a/scripts/pagopa_api_check.sh
+++ b/scripts/pagopa_api_check.sh
@@ -9,39 +9,60 @@ while IFS= read -r line; do
     if [[ $line =~ PAGOPA_API_URL_PREFIX=.* ]]; then
         # take the value a strip the string
         PAGOPA_API_URL_PREFIX=$(echo $line | cut -d'=' -f 2 | tr -d "\'" | tr -d '[:space:]')
-        PAGOPA_API_URL_PREFIX="$PAGOPA_API_URL_PREFIX$PAGOPA_API_URL_SUFFIX"
     fi
     if [[ $line =~ PAGOPA_API_URL_PREFIX_TEST=.* ]]; then
         # take the value a strip the string
         PAGOPA_API_URL_PREFIX_TEST=$(echo $line | cut -d'=' -f 2 | tr -d "\'" | tr -d '[:space:]')
-        PAGOPA_API_URL_PREFIX_TEST="$PAGOPA_API_URL_PREFIX_TEST$PAGOPA_API_URL_SUFFIX"
     fi
 done < "$input"
-# regex pattern to handle only hosts url difference
-NO_CHANGES_REGEX='.*.*<.*"host": ".*",.*---.*>.*"host": ".*",'
 
 printf "### COMPARING SWAGGER DEFINITIONS ###\n\n"
-printf "%14s $PAGOPA_API_URL_PREFIX\n" "production:" 
-printf "%14s $PAGOPA_API_URL_PREFIX_TEST\n" "test:" 
+printf "%14s $PAGOPA_API_URL_PREFIX$PAGOPA_API_URL_SUFFIX\n" "production:" 
+printf "%14s $PAGOPA_API_URL_PREFIX_TEST$PAGOPA_API_URL_SUFFIX\n" "test:" 
+
 
 SEND_MSG="✅ pagopa production and test specifications have no differences"
 SEND_EXIT=0
 # mention matteo boschi slack account
 MB_SLACK="<@UGP1H4GLR>" 
-DIFF=$(diff -w -B <(curl -s $PAGOPA_API_URL_PREFIX | python -m json.tool) <(curl -s $PAGOPA_API_URL_PREFIX_TEST | python -m json.tool))
-printf "\n\n"
-if [ -n "$DIFF" ]; then
-    if [[ $DIFF =~ $NO_CHANGES_REGEX ]]; then
-        echo $SEND_MSG
-    else
-        KO_MSG="⚠ $MB_SLACK ko. It seems *PROD* and *DEV* pagoPa specifications are different"
-        echo "It seems PROD and DEV pagoPa specifications are different"
-        echo $DIFF
-        SEND_MSG=$KO_MSG
-        SEND_EXIT=1
-        #send slack notification
-        channel="#io-status"
-        res=$(curl -s -X POST -H 'Content-type: application/json' --data '{"text":"'"$SEND_MSG"'", "channel" : "'$channel'"}' ${ITALIAAPP_SLACK_TOKEN_PAGOPA_CHECK:-})
-    fi
+
+# json formatting (python pipe) is needed because diff command works by comparing line by line
+PAGO_PA_PROD_CONTENT=$(curl -s $PAGOPA_API_URL_PREFIX$PAGOPA_API_URL_SUFFIX | python -m json.tool)
+# remove the host section because this is the only part surely different between specs
+PAGO_PA_PROD_CONTENT=$(echo $PAGO_PA_PROD_CONTENT | perl -pe "s/\"host\":\s+\".*?\",//")
+
+PAGO_PA_TEST_CONTENT=$(curl -s $PAGOPA_API_URL_PREFIX_TEST$PAGOPA_API_URL_SUFFIX | python -m json.tool)
+PAGO_PA_TEST_CONTENT=$(echo $PAGO_PA_TEST_CONTENT | perl -pe "s/\"host\":\s+\".*?\",//")
+
+# uncomment lines below to run a test on same specs
+#PAGO_PA_PROD_CONTENT=$(curl -s $PAGOPA_API_URL_PREFIX_TEST$PAGOPA_API_URL_SUFFIX | python -m json.tool)
+#PAGO_PA_TEST_CONTENT=$(echo $PAGO_PA_TEST_CONTENT | perl -pe "s/\"host\":\s+\".*?\",//")
+#PAGO_PA_TEST_CONTENT=$PAGO_PA_PROD_CONTENT
+
+# uncomment lines below to run a test on different specs
+#PAGO_PA_PROD_CONTENT=$(curl -s $PAGOPA_API_URL_PREFIX_TEST$PAGOPA_API_URL_SUFFIX | python -m json.tool)
+#PAGO_PA_PROD_CONTENT=$(echo $PAGO_PA_PROD_CONTENT | perl -pe "s/\"host\":\s+\".*?\",//")
+#DIFFERENT_JSON_URL=https://api.myjson.com/bins/7bykb # same json as PAGO_PA_PROD_CONTENT but with 1 deletion and 1 addition
+#PAGO_PA_TEST_CONTENT=$(curl -s $DIFFERENT_JSON_URL | python -m json.tool)
+#PAGO_PA_TEST_CONTENT=$(echo $PAGO_PA_TEST_CONTENT | perl -pe "s/\"host\":\s+\".*?\",//")
+
+
+# check the diff between prod/test specs
+DIFF=$(diff -w -B <(echo $PAGO_PA_PROD_CONTENT) <(echo $PAGO_PA_TEST_CONTENT))
+VAR_LENGTH=${#DIFF}
+printf "\n"
+
+# check if diff output is an empty string (no difference)
+if [ $VAR_LENGTH -eq "0" ]; then
+    echo $SEND_MSG
+else
+    KO_MSG="⚠️ $MB_SLACK ko. It seems *PROD* and *DEV* pagoPa specifications are different"
+    echo "⚠️  It seems PROD and DEV pagoPa specifications are different"
+    SEND_MSG=$KO_MSG
+    SEND_EXIT=1
+    #send slack notification
+    channel="#io-status"
+    #res=$(curl -s -X POST -H 'Content-type: application/json' --data '{"text":"'"$SEND_MSG"'", "channel" : "'$channel'"}' ${ITALIAAPP_SLACK_TOKEN_PAGOPA_CHECK:-})
 fi
+
 exit $SEND_EXIT

--- a/scripts/pagopa_api_check.sh
+++ b/scripts/pagopa_api_check.sh
@@ -62,7 +62,7 @@ else
     SEND_EXIT=1
     #send slack notification
     channel="#io-status"
-    #res=$(curl -s -X POST -H 'Content-type: application/json' --data '{"text":"'"$SEND_MSG"'", "channel" : "'$channel'"}' ${ITALIAAPP_SLACK_TOKEN_PAGOPA_CHECK:-})
+    res=$(curl -s -X POST -H 'Content-type: application/json' --data '{"text":"'"$SEND_MSG"'", "channel" : "'$channel'"}' ${ITALIAAPP_SLACK_TOKEN_PAGOPA_CHECK:-})
 fi
 
 exit $SEND_EXIT

--- a/scripts/pagopa_api_check.sh
+++ b/scripts/pagopa_api_check.sh
@@ -56,7 +56,7 @@ printf "\n"
 if [ $VAR_LENGTH -eq "0" ]; then
     echo $SEND_MSG
 else
-    KO_MSG="⚠️ $MB_SLACK ko. It seems *PROD* and *DEV* pagoPa specifications are different"
+    KO_MSG="⚠️ $MB_SLACK It seems *PROD* and *DEV* pagoPa specifications are different"
     echo "⚠️  It seems PROD and DEV pagoPa specifications are different"
     SEND_MSG=$KO_MSG
     SEND_EXIT=1


### PR DESCRIPTION
This PR aims to fix the nightly job that checks if there are differences from pagoPa specs **production**/**test**

Different from previous implementation, to skip the hosts difference, now **_host_** section will be removed from both specs file just before execute **diff** command