### PR TITLE
[#167106329] add paid style to cta button

### DIFF
--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -579,7 +579,7 @@ messages:
         block5: alle
         block6: del
     pay: Paga € {{amount}}
-    paid: Pagato € {{amount}}
+    paid: Pagati € {{amount}}
     reminder: Promemoria
     reminderShort: Memo
     reminderCalendarSelect: In quale calendario vuoi aggiungere il promemoria?

--- a/ts/components/messages/MessageCTABar.tsx
+++ b/ts/components/messages/MessageCTABar.tsx
@@ -1,3 +1,9 @@
+/**
+ * A component to show the action buttons on a message.
+ * For messages with the proper configuration, the user can:
+ * - add a message-related calendar event
+ * - start the message-related payment
+ */
 import { isToday } from "date-fns";
 import { fromNullable, Option } from "fp-ts/lib/Option";
 import { capitalize } from "lodash";
@@ -409,7 +415,7 @@ class MessageCTABar extends React.PureComponent<Props, State> {
               initialAmount: amount.value
             });
           }
-        : undefined;
+        : paid ? this.navigateToMessageDetail : undefined ;
 
     return (
       <PaymentButton

--- a/ts/components/messages/MessageCTABar.tsx
+++ b/ts/components/messages/MessageCTABar.tsx
@@ -415,14 +415,14 @@ class MessageCTABar extends React.PureComponent<Props, State> {
               initialAmount: amount.value
             });
           }
-        : paid ? this.navigateToMessageDetail : undefined ;
+        : undefined;
 
     return (
       <PaymentButton
         paid={paid}
         messagePaymentExpirationInfo={messagePaymentExpirationInfo}
         small={small}
-        disabled={onPressHandler === undefined}
+        disabled={disabled}
         onPress={onPressHandler}
       />
     );

--- a/ts/components/messages/PaymentButton.tsx
+++ b/ts/components/messages/PaymentButton.tsx
@@ -108,7 +108,8 @@ const smallStyles = StyleSheet.create({
 
 const disabledStyles = StyleSheet.create({
   button: {
-    backgroundColor: "#b5b5b5"
+    backgroundColor: "#b5b5b5",
+    borderWidth: 0
   },
 
   icon: {
@@ -176,6 +177,7 @@ const getButtonText = (
 };
 
 class PaymentButton extends React.PureComponent<Props> {
+  // tslint:disable-next-line: cognitive-complexity
   public render() {
     const {
       paid,
@@ -198,15 +200,15 @@ class PaymentButton extends React.PureComponent<Props> {
 
     return (
       <Button
-        disabled={disabled}
+        disabled={disabled || paid}
         light={true}
         onPress={paid ? undefined : onPress}
         style={[
           baseStyles.button,
           appliedStyles.button,
           small && smallStyles.button,
-          disabled && disabledStyles.button,
-          paid && paidStyles.button
+          paid && paidStyles.button,
+          disabled && disabledStyles.button
         ]}
       >
         {!hideIcon ||
@@ -219,17 +221,19 @@ class PaymentButton extends React.PureComponent<Props> {
                 small && smallStyles.icon,
                 disabled && disabledStyles.icon
               ]}
-              color={paid && customVariables.brandHighlight}
+              color={
+                paid && !disabled ? customVariables.brandHighlight : undefined
+              }
             />
           ))}
         <Text
-          bold={paid && true}
+          bold={true}
           style={[
             baseStyles.text,
             appliedStyles.text,
             small && smallStyles.text,
-            disabled && disabledStyles.text,
-            paid && paidStyles.text
+            paid && paidStyles.text,
+            disabled && disabledStyles.text
           ]}
         >
           {getButtonText(messagePaymentExpirationInfo, paid)}

--- a/ts/components/messages/PaymentButton.tsx
+++ b/ts/components/messages/PaymentButton.tsx
@@ -120,6 +120,18 @@ const disabledStyles = StyleSheet.create({
   }
 });
 
+const paidStyles = StyleSheet.create({
+  button: {
+    backgroundColor: customVariables.colorWhite,
+    borderColor: customVariables.brandHighlight,
+    borderWidth: 1
+  },
+
+  text: {
+    color: customVariables.brandHighlight
+  }
+});
+
 const getExpirationStyles = (
   messagePaymentExpirationInfo: MessagePaymentExpirationInfo,
   small: boolean = false
@@ -140,9 +152,16 @@ const getExpirationStyles = (
 };
 
 const getButtonText = (
-  messagePaymentExpirationInfo: MessagePaymentExpirationInfo
+  messagePaymentExpirationInfo: MessagePaymentExpirationInfo,
+  paid: boolean
 ): string => {
   const { amount } = messagePaymentExpirationInfo;
+
+  if (paid) {
+    return I18n.t("messages.cta.paid", {
+      amount: formatPaymentAmount(amount)
+    });
+  }
 
   if (
     messagePaymentExpirationInfo.kind === "EXPIRABLE" &&
@@ -175,28 +194,31 @@ class PaymentButton extends React.PureComponent<Props> {
     const isExpired =
       messagePaymentExpirationInfo.kind === "EXPIRABLE" &&
       messagePaymentExpirationInfo.expireStatus === "EXPIRED";
-    const hideIcon = paid || isUnexpirable || isExpired || !small;
+    const hideIcon = isUnexpirable || isExpired || !small;
 
     return (
       <Button
         disabled={disabled}
-        onPress={onPress}
+        light={true}
+        onPress={paid ? undefined : onPress}
         style={[
           baseStyles.button,
           appliedStyles.button,
           small && smallStyles.button,
-          disabled && disabledStyles.button
+          disabled && disabledStyles.button,
+          paid && paidStyles.button
         ]}
       >
-        {!hideIcon && (
+        {!hideIcon  || paid && (
           <IconFont
-            name="io-timer"
+            name={paid ? 'io-tick-big' : "io-timer"}
             style={[
               baseStyles.icon,
               appliedStyles.icon,
               small && smallStyles.icon,
-              disabled && disabledStyles.icon
+              disabled && disabledStyles.icon,
             ]}
+            color={paid && customVariables.brandHighlight}
           />
         )}
         <Text
@@ -204,10 +226,11 @@ class PaymentButton extends React.PureComponent<Props> {
             baseStyles.text,
             appliedStyles.text,
             small && smallStyles.text,
-            disabled && disabledStyles.text
+            disabled && disabledStyles.text,
+            paid && paidStyles.text
           ]}
         >
-          {getButtonText(messagePaymentExpirationInfo)}
+          {getButtonText(messagePaymentExpirationInfo, paid)}
         </Text>
       </Button>
     );

--- a/ts/components/messages/PaymentButton.tsx
+++ b/ts/components/messages/PaymentButton.tsx
@@ -1,7 +1,7 @@
 /**
- * A component to render the button related to a payment 
+ * A component to render the button related to a payment
  * pired with a message.
- * 
+ *
  */
 import { Button, Text } from "native-base";
 import React, { ComponentProps } from "react";

--- a/ts/components/messages/PaymentButton.tsx
+++ b/ts/components/messages/PaymentButton.tsx
@@ -1,3 +1,8 @@
+/**
+ * A component to render the button related to a payment 
+ * pired with a message.
+ * 
+ */
 import { Button, Text } from "native-base";
 import React, { ComponentProps } from "react";
 import { StyleSheet } from "react-native";

--- a/ts/components/messages/PaymentButton.tsx
+++ b/ts/components/messages/PaymentButton.tsx
@@ -209,18 +209,19 @@ class PaymentButton extends React.PureComponent<Props> {
           paid && paidStyles.button
         ]}
       >
-        {!hideIcon  || paid && (
-          <IconFont
-            name={paid ? 'io-tick-big' : "io-timer"}
-            style={[
-              baseStyles.icon,
-              appliedStyles.icon,
-              small && smallStyles.icon,
-              disabled && disabledStyles.icon,
-            ]}
-            color={paid && customVariables.brandHighlight}
-          />
-        )}
+        {!hideIcon ||
+          (paid && (
+            <IconFont
+              name={paid ? "io-tick-big" : "io-timer"}
+              style={[
+                baseStyles.icon,
+                appliedStyles.icon,
+                small && smallStyles.icon,
+                disabled && disabledStyles.icon
+              ]}
+              color={paid && customVariables.brandHighlight}
+            />
+          ))}
         <Text
           style={[
             baseStyles.text,

--- a/ts/components/messages/PaymentButton.tsx
+++ b/ts/components/messages/PaymentButton.tsx
@@ -223,6 +223,7 @@ class PaymentButton extends React.PureComponent<Props> {
             />
           ))}
         <Text
+          bold={paid && true}
           style={[
             baseStyles.text,
             appliedStyles.text,


### PR DESCRIPTION
This pr implements the designed style for CTA pay button if the transaction paired with the message had been completed.
![paid2](https://user-images.githubusercontent.com/38431762/60734706-12e9f280-9f51-11e9-805a-7f3c7b33f602.gif)




