### PR TITLE
[#166761429] Check if user has not supported wallets only

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -343,7 +343,7 @@ wallet:
     addButton: Add a new method
     addDescription: You can add your payment methods (e.g. credit cards, bank accounts)
       so that you don't have to re-add them from scratch for every transaction.
-    walletAlert: "Warning: your wallet includes payment methods but no one is supported by IO yet"
+    walletAlert: "Your wallet includes payment methods but no one is supported by IO yet"
     successful: The card was added successfully!
     failed: The card could not be added
     failedCardAlreadyExists: The card you are adding already exists

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -343,7 +343,7 @@ wallet:
     addButton: Add a new method
     addDescription: You can add your payment methods (e.g. credit cards, bank accounts)
       so that you don't have to re-add them from scratch for every transaction.
-    walletAlert: "Warning: your payment methods are not yet supported"
+    walletAlert: "Warning: your wallet includes payment methods but no one is supported by IO yet"
     successful: The card was added successfully!
     failed: The card could not be added
     failedCardAlreadyExists: The card you are adding already exists

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -342,7 +342,8 @@ wallet:
     add: add
     addButton: Add a new method
     addDescription: You can add your payment methods (e.g. credit cards, bank accounts)
-      so that you don't have to re-add them from scratch for every transaction
+      so that you don't have to re-add them from scratch for every transaction.
+    walletAlert: "Warning: your payment methods are not yet supported"
     successful: The card was added successfully!
     failed: The card could not be added
     failedCardAlreadyExists: The card you are adding already exists

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -350,7 +350,8 @@ wallet:
     add: aggiungi
     addButton: Aggiungi un metodo
     addDescription: Puoi aggiungere i tuoi metodi di pagamento (carte, conti correnti,
-      ecc.) per non doverli inserire ad ogni transazione
+      ecc.) per non doverli inserire ad ogni transazione.
+    walletAlert: "Attenzione: i tuoi metodi di pagamento non sono attualmente supportati"
     successful: Carta aggiunta con successo
     failed: Impossibile aggiungere la carta
     failedCardAlreadyExists: La carta che stai inserendo è già presente

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -351,7 +351,7 @@ wallet:
     addButton: Aggiungi un metodo
     addDescription: Puoi aggiungere i tuoi metodi di pagamento (carte, conti correnti,
       ecc.) per non doverli inserire ad ogni transazione.
-    walletAlert: "Attenzione: nel tuo portafoglio sono registrati dei metodi di pagamento ma nessuno di questi è compatibile con IO"
+    walletAlert: "Nel tuo portafoglio sono registrati dei metodi di pagamento ma nessuno di questi è compatibile con IO"
     successful: Carta aggiunta con successo
     failed: Impossibile aggiungere la carta
     failedCardAlreadyExists: La carta che stai inserendo è già presente

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -351,7 +351,7 @@ wallet:
     addButton: Aggiungi un metodo
     addDescription: Puoi aggiungere i tuoi metodi di pagamento (carte, conti correnti,
       ecc.) per non doverli inserire ad ogni transazione.
-    walletAlert: "Attenzione: i tuoi metodi di pagamento non sono attualmente supportati"
+    walletAlert: "Attenzione: nel tuo portafoglio sono registrati dei metodi di pagamento ma nessuno di questi è compatibile con IO"
     successful: Carta aggiunta con successo
     failed: Impossibile aggiungere la carta
     failedCardAlreadyExists: La carta che stai inserendo è già presente

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -159,16 +159,14 @@ class WalletHomeScreen extends React.Component<Props, never> {
         <Row>
           <Text note={true} white={true} style={styles.inLineSpace}>
             {I18n.t("wallet.newPaymentMethod.addDescription")}
+            {hasNoValidWallets && (
+              <Text note={true} white={true} bold={true}>
+                {` ${I18n.t("wallet.newPaymentMethod.walletAlert")}`}
+              </Text>
+            )}
           </Text>
         </Row>
-        <Row>
-          {hasNoValidWallets && (
-            <Text note={true} white={true}>
-              Attenzione: i tuoi metodi di pagamento non sono attualmente
-              supportati
-            </Text>
-          )}
-        </Row>
+        <Row />
         <Row>
           <View spacer={true} />
         </Row>

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -162,7 +162,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
           </Text>
         </Row>
         <Row>
-          {!hasNoValidWallets && (
+          {hasNoValidWallets && (
             <Text note={true} white={true}>
               Attenzione: i tuoi metodi di pagamento non sono attualmente
               supportati

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -311,9 +311,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
       wallets.length > 0 &&
       wallets
         .map(wallet => {
-          return (
-            wallet.type !== TypeEnum.CREDIT_CARD
-          );
+          return wallet.type !== TypeEnum.CREDIT_CARD;
         })
         .find(isNoCard => isNoCard === true);
 

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -153,7 +153,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
     );
   }
 
-  private withoutCardsHeader(hasNotSupportedWallets: boolean = false) {
+  private withoutCardsHeader(hasNotSupportedWallets: boolean) {
     return (
       <Grid>
         <Row>
@@ -313,7 +313,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
         .map(wallet => {
           return wallet.type !== TypeEnum.CREDIT_CARD;
         })
-        .find(isNoCard => isNoCard === true);
+        .find(isNoCard => isNoCard === true) !== undefined;
 
     const headerContent = pot.isLoading(potWallets)
       ? this.loadingWalletsHeader()

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -312,8 +312,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
       wallets
         .map(wallet => {
           return (
-            wallet.type === TypeEnum.BANK_ACCOUNT ||
-            wallet.type === TypeEnum.EXTERNAL_PS
+            wallet.type !== TypeEnum.CREDIT_CARD
           );
         })
         .find(isNoCard => isNoCard === true);

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -12,6 +12,7 @@ import { Grid, Row } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
+import { TypeEnum } from "../../../definitions/pagopa/Wallet";
 import BoxedRefreshIndicator from "../../components/ui/BoxedRefreshIndicator";
 import H5 from "../../components/ui/H5";
 import IconFont from "../../components/ui/IconFont";
@@ -152,13 +153,21 @@ class WalletHomeScreen extends React.Component<Props, never> {
     );
   }
 
-  private withoutCardsHeader() {
+  private withoutCardsHeader(hasNoValidWallets: boolean = false) {
     return (
       <Grid>
         <Row>
           <Text note={true} white={true} style={styles.inLineSpace}>
             {I18n.t("wallet.newPaymentMethod.addDescription")}
           </Text>
+        </Row>
+        <Row>
+          {!hasNoValidWallets && (
+            <Text note={true} white={true}>
+              Attenzione: i tuoi metodi di pagamento non sono attualmente
+              supportati
+            </Text>
+          )}
         </Row>
         <Row>
           <View spacer={true} />
@@ -297,14 +306,25 @@ class WalletHomeScreen extends React.Component<Props, never> {
 
   public render(): React.ReactNode {
     const { potWallets, potTransactions } = this.props;
+
     const wallets = pot.getOrElse(potWallets, []);
+
+    const hasNoValidWallets = wallets
+      .map(wallet => {
+        return (
+          wallet.type === TypeEnum.BANK_ACCOUNT ||
+          wallet.type === TypeEnum.EXTERNAL_PS
+        );
+      })
+      .find(isNoCard => isNoCard === true);
+
     const headerContent = pot.isLoading(potWallets)
       ? this.loadingWalletsHeader()
       : pot.isError(potWallets)
         ? this.errorWalletsHeader()
         : wallets.length > 0
           ? this.cardPreview(wallets)
-          : this.withoutCardsHeader();
+          : this.withoutCardsHeader(hasNoValidWallets);
 
     const transactionContent = pot.isError(potTransactions)
       ? this.transactionError()

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -153,13 +153,13 @@ class WalletHomeScreen extends React.Component<Props, never> {
     );
   }
 
-  private withoutCardsHeader(hasNoValidWallets: boolean = false) {
+  private withoutCardsHeader(hasNotSupportedWallets: boolean = false) {
     return (
       <Grid>
         <Row>
           <Text note={true} white={true} style={styles.inLineSpace}>
             {I18n.t("wallet.newPaymentMethod.addDescription")}
-            {hasNoValidWallets && (
+            {hasNotSupportedWallets && (
               <Text note={true} white={true} bold={true}>
                 {` ${I18n.t("wallet.newPaymentMethod.walletAlert")}`}
               </Text>
@@ -307,7 +307,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
 
     const wallets = pot.getOrElse(potWallets, []);
 
-    const hasNoValidWallets = wallets
+    const hasNotSupportedWallets = wallets
       .map(wallet => {
         return (
           wallet.type === TypeEnum.BANK_ACCOUNT ||
@@ -322,7 +322,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
         ? this.errorWalletsHeader()
         : wallets.length > 0
           ? this.cardPreview(wallets)
-          : this.withoutCardsHeader(hasNoValidWallets);
+          : this.withoutCardsHeader(hasNotSupportedWallets);
 
     const transactionContent = pot.isError(potTransactions)
       ? this.transactionError()

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -307,14 +307,16 @@ class WalletHomeScreen extends React.Component<Props, never> {
 
     const wallets = pot.getOrElse(potWallets, []);
 
-    const hasNotSupportedWallets = wallets
-      .map(wallet => {
-        return (
-          wallet.type === TypeEnum.BANK_ACCOUNT ||
-          wallet.type === TypeEnum.EXTERNAL_PS
-        );
-      })
-      .find(isNoCard => isNoCard === true);
+    const hasNotSupportedWallets =
+      wallets.length > 0 &&
+      wallets
+        .map(wallet => {
+          return (
+            wallet.type === TypeEnum.BANK_ACCOUNT ||
+            wallet.type === TypeEnum.EXTERNAL_PS
+          );
+        })
+        .find(isNoCard => isNoCard === true);
 
     const headerContent = pot.isLoading(potWallets)
       ? this.loadingWalletsHeader()

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -153,13 +153,13 @@ class WalletHomeScreen extends React.Component<Props, never> {
     );
   }
 
-  private withoutCardsHeader(hasNotSupportedWallets: boolean) {
+  private withoutCardsHeader(hasNotSupportedWalletsOnly: boolean) {
     return (
       <Grid>
         <Row>
           <Text note={true} white={true} style={styles.inLineSpace}>
             {I18n.t("wallet.newPaymentMethod.addDescription")}
-            {hasNotSupportedWallets && (
+            {hasNotSupportedWalletsOnly && (
               <Text note={true} white={true} bold={true}>
                 {` ${I18n.t("wallet.newPaymentMethod.walletAlert")}`}
               </Text>
@@ -307,13 +307,10 @@ class WalletHomeScreen extends React.Component<Props, never> {
 
     const wallets = pot.getOrElse(potWallets, []);
 
-    const hasNotSupportedWallets =
+    const hasNotSupportedWalletsOnly =
       wallets.length > 0 &&
-      wallets
-        .map(wallet => {
-          return wallet.type !== TypeEnum.CREDIT_CARD;
-        })
-        .find(isNoCard => isNoCard === true) !== undefined;
+      wallets.filter(wallet => wallet.type === TypeEnum.CREDIT_CARD).length ===
+        0;
 
     const headerContent = pot.isLoading(potWallets)
       ? this.loadingWalletsHeader()
@@ -321,7 +318,7 @@ class WalletHomeScreen extends React.Component<Props, never> {
         ? this.errorWalletsHeader()
         : wallets.length > 0
           ? this.cardPreview(wallets)
-          : this.withoutCardsHeader(hasNotSupportedWallets);
+          : this.withoutCardsHeader(hasNotSupportedWalletsOnly);
 
     const transactionContent = pot.isError(potTransactions)
       ? this.transactionError()


### PR DESCRIPTION
This pr introduces a check on the user's wallet. If it includes wallets which are not a CREDIT_CARD type, the user displays an alert advising his wallets are not supported on IO app.

<img width="561" alt="image" src="https://user-images.githubusercontent.com/38431762/61276683-c86a4080-a7b0-11e9-95f8-49359239a786.png">


TODO: test it with a no mocked account having not supported wallets