### PR TITLE
[#166761737] Fixed the services list alphabetical order

### DIFF
--- a/ts/screens/preferences/OldServicesHomeScreen.tsx
+++ b/ts/screens/preferences/OldServicesHomeScreen.tsx
@@ -146,7 +146,11 @@ export const getAllSections = createSelector(
         };
       })
       .filter(_ => _.data.length > 0)
-      .sort((a, b) => (a.title || "").localeCompare(b.title));
+      .sort((a, b) =>
+        (a.title.toLocaleLowerCase() || "").localeCompare(
+          b.title.toLocaleLowerCase()
+        )
+      );
   }
 );
 

--- a/ts/screens/preferences/OldServicesHomeScreen.tsx
+++ b/ts/screens/preferences/OldServicesHomeScreen.tsx
@@ -147,9 +147,7 @@ export const getAllSections = createSelector(
       })
       .filter(_ => _.data.length > 0)
       .sort((a, b) =>
-        (a.title.toLocaleLowerCase() || "").localeCompare(
-          b.title.toLocaleLowerCase()
-        )
+        (a.title || "").localeCompare(b.title, "it", { caseFirst: "lower" })
       );
   }
 );


### PR DESCRIPTION
The list of services is now correctly ordered.

<img src="https://user-images.githubusercontent.com/8174240/61295617-bdc3a180-a7d8-11e9-8420-1cc7a332f2ee.gif" width="50%">