### PR TITLE
[#167400108] Fix crash on Android 5.1

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -88,3 +88,8 @@
 
 #Instabug
 -dontwarn com.instabug.**
+
+# React-native Keychain
+-keep class com.facebook.crypto.** {
+   *;
+}


### PR DESCRIPTION
Fixed the crash on Android 5.1 by adding a new rule in proguard.