### PR TITLE
[#167479784] Fix undefined on test attribute value at payment activation 

### DIFF
--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -91,14 +91,17 @@ const migrations: MigrationManifest = {
   // Version 4
   // we added a state to monitor what pagopa environment is selected
   "4": (state: PersistedState) => {
-    const oldPersistedState = (state as any).persistedPreferences;
-    return {
-      ...state,
-      persistedPreferences: {
-        ...oldPersistedState,
-        isPagoPATestEnabled: false
-      }
-    };
+    return (state as any).persistedPreferences.isPagoPATestEnabled === undefined
+      ? {
+          ...state,
+          persistedPreferences: {
+            ...(state as any).persistedPreferences,
+            isPagoPATestEnabled: false
+          }
+        }
+      : {
+          ...state
+        };
   }
 };
 

--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -33,7 +33,7 @@ import { NAVIGATION_MIDDLEWARE_LISTENERS_KEY } from "../utils/constants";
 /**
  * Redux persist will migrate the store to the current version
  */
-const CURRENT_REDUX_STORE_VERSION = 3;
+const CURRENT_REDUX_STORE_VERSION = 4;
 
 // see redux-persist documentation:
 // https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md
@@ -84,6 +84,19 @@ const migrations: MigrationManifest = {
           nameByFiscalCode: orgNameByFiscalCode ? orgNameByFiscalCode : {},
           all: allOrganizations ? allOrganizations : {}
         }
+      }
+    };
+  },
+
+  // Version 4
+  // we added a state to monitor what pagopa environment is selected
+  "4": (state: PersistedState) => {
+    const oldPersistedState = (state as any).persistedPreferences;
+    return {
+      ...state,
+      persistedPreferences: {
+        ...oldPersistedState,
+        isPagoPATestEnabled: false
       }
     };
   }


### PR DESCRIPTION
This pr properly migrates the usage of the persisted state isPagoPATestEnabled. When introduced, this state was not migrated and it resulted in the value undefined when calling the backend for those users using the app before the pagopa test enviroment was re-introduced. 

Now, for these kind of users, the state isPagoPATestEnabled is set as default to **false**.