### PR TITLE
[#168141240] Fix bug if sender is unknown

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -575,7 +575,8 @@ messages:
   errorLoading:
     details: Error loading message details
     senderService:  Sender service unknown
-    senderInfo: Service info unknown
+    serviceInfo: Service info unknown
+    departmentInfo: Department info unknown
   cta:
     archive: Archive
     unarchive: Unarchive

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -574,7 +574,7 @@ messages:
   yesterday: yesterday
   errorLoading:
     details: Error loading message details
-    senderService:  Sender service unknown
+    senderInfo:  Sender service unknown
     serviceInfo: Service info unknown
     departmentInfo: Department info unknown
   cta:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -584,7 +584,7 @@ messages:
   yesterday: ieri
   errorLoading:
     details: Impossibile caricare i dettagli del messaggio
-    senderService:  Mittente sconosciuto
+    senderInfo:  Mittente sconosciuto
     serviceInfo: Info sul servizio mancanti
     departmentInfo: Info sul dipartimento mancanti
   cta:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -585,7 +585,8 @@ messages:
   errorLoading:
     details: Impossibile caricare i dettagli del messaggio
     senderService:  Mittente sconosciuto
-    senderInfo: Info sul servizio mancanti
+    serviceInfo: Info sul servizio mancanti
+    departmentInfo: Info sul dipartimento mancanti
   cta:
     archive: Archivia
     unarchive: Ripristina

--- a/ts/components/messages/MessageAgenda.tsx
+++ b/ts/components/messages/MessageAgenda.tsx
@@ -337,8 +337,8 @@ class MessageAgenda extends React.PureComponent<Props, State> {
       potService !== undefined
         ? pot.isNone(potService)
           ? ({
-              organization_name: I18n.t("messages.errorLoading.senderService"),
-              department_name: I18n.t("messages.errorLoading.senderInfo")
+              organization_name: I18n.t("messages.errorLoading.senderInfo"),
+              department_name: I18n.t("messages.errorLoading.serviceInfo")
             } as ServicePublic)
           : pot.toUndefined(potService)
         : undefined;

--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -102,7 +102,7 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
       potService !== undefined
         ? pot.isNone(potService)
           ? ({
-              organization_name: I18n.t("messages.errorLoading.senderService"),
+              organization_name: I18n.t("messages.errorLoading.senderInfo"),
               department_name: I18n.t("messages.errorLoading.departmentInfo"),
               service_name: I18n.t("messages.errorLoading.serviceInfo")
             } as ServicePublic)

--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -121,24 +121,26 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
       <View style={styles.mainWrapper}>
         <View style={styles.headerContainer}>
           {/* Service */}
-          {service && (
-            <Grid style={styles.serviceContainer}>
-              <Col>
-                <H4>{service.organization_name}</H4>
-                <H6 link={true} onPress={onServiceLinkPress}>
-                  {service.service_name}
-                </H6>
-              </Col>
-              <Col style={styles.serviceCol}>
-                <TouchableOpacity onPress={onServiceLinkPress}>
-                  <MultiImage
-                    style={styles.serviceMultiImage}
-                    source={logosForService(service)}
-                  />
-                </TouchableOpacity>
-              </Col>
-            </Grid>
-          )}
+          {service &&
+            service.service_id &&
+            pot.isSome(potService) && (
+              <Grid style={styles.serviceContainer}>
+                <Col>
+                  <H4>{service.organization_name}</H4>
+                  <H6 link={true} onPress={onServiceLinkPress}>
+                    {service.service_name}
+                  </H6>
+                </Col>
+                <Col style={styles.serviceCol}>
+                  <TouchableOpacity onPress={onServiceLinkPress}>
+                    <MultiImage
+                      style={styles.serviceMultiImage}
+                      source={logosForService(service)}
+                    />
+                  </TouchableOpacity>
+                </Col>
+              </Grid>
+            )}
 
           {/* Subject */}
           <View style={styles.subjectContainer}>

--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -103,7 +103,8 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
         ? pot.isNone(potService)
           ? ({
               organization_name: I18n.t("messages.errorLoading.senderService"),
-              department_name: I18n.t("messages.errorLoading.senderInfo")
+              department_name: I18n.t("messages.errorLoading.senderInfo"),
+              service_name: I18n.t("messages.errorLoading.senderInfo")
             } as ServicePublic)
           : pot.toUndefined(potService)
         : undefined;
@@ -121,16 +122,15 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
       <View style={styles.mainWrapper}>
         <View style={styles.headerContainer}>
           {/* Service */}
-          {service &&
-            service.service_id &&
-            pot.isSome(potService) && (
-              <Grid style={styles.serviceContainer}>
-                <Col>
-                  <H4>{service.organization_name}</H4>
-                  <H6 link={true} onPress={onServiceLinkPress}>
-                    {service.service_name}
-                  </H6>
-                </Col>
+          {service && (
+            <Grid style={styles.serviceContainer}>
+              <Col>
+                <H4>{service.organization_name}</H4>
+                <H6 link={true} onPress={onServiceLinkPress}>
+                  {service.service_name}
+                </H6>
+              </Col>
+              {service.service_id && (
                 <Col style={styles.serviceCol}>
                   <TouchableOpacity onPress={onServiceLinkPress}>
                     <MultiImage
@@ -139,8 +139,9 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
                     />
                   </TouchableOpacity>
                 </Col>
-              </Grid>
-            )}
+              )}
+            </Grid>
+          )}
 
           {/* Subject */}
           <View style={styles.subjectContainer}>

--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -103,8 +103,8 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
         ? pot.isNone(potService)
           ? ({
               organization_name: I18n.t("messages.errorLoading.senderService"),
-              department_name: I18n.t("messages.errorLoading.senderInfo"),
-              service_name: I18n.t("messages.errorLoading.senderInfo")
+              department_name: I18n.t("messages.errorLoading.departmentInfo"),
+              service_name: I18n.t("messages.errorLoading.serviceInfo")
             } as ServicePublic)
           : pot.toUndefined(potService)
         : undefined;

--- a/ts/components/messages/MessageList.tsx
+++ b/ts/components/messages/MessageList.tsx
@@ -249,8 +249,8 @@ class MessageList extends React.Component<Props, State> {
       potService !== undefined
         ? pot.isNone(potService)
           ? ({
-              organization_name: I18n.t("messages.errorLoading.senderService"),
-              department_name: I18n.t("messages.errorLoading.senderInfo")
+              organization_name: I18n.t("messages.errorLoading.senderInfo"),
+              department_name: I18n.t("messages.errorLoading.serviceInfo")
             } as ServicePublic)
           : pot.toUndefined(potService)
         : undefined;

--- a/ts/components/messages/MessageListItem.tsx
+++ b/ts/components/messages/MessageListItem.tsx
@@ -112,8 +112,8 @@ const styles = StyleSheet.create({
 });
 
 const UNKNOWN_SERVICE_DATA = {
-  organizationName: "Mittente sconosciuto",
-  departmentName: "Info sul servizio mancanti"
+  organizationName: I18n.t("messages.errorLoading.senderService"),
+  departmentName: I18n.t("messages.errorLoading.senderInfo")
 };
 
 class MessageListItem extends React.PureComponent<Props> {

--- a/ts/components/messages/MessageListItem.tsx
+++ b/ts/components/messages/MessageListItem.tsx
@@ -116,8 +116,8 @@ const styles = StyleSheet.create({
 });
 
 const UNKNOWN_SERVICE_DATA = {
-  organizationName: I18n.t("messages.errorLoading.senderService"),
-  departmentName: I18n.t("messages.errorLoading.senderInfo")
+  organizationName: I18n.t("messages.errorLoading.senderInfo"),
+  departmentName: I18n.t("messages.errorLoading.serviceInfo")
 };
 
 class MessageListItem extends React.PureComponent<Props> {


### PR DESCRIPTION
This pr solves the bug causing error screen if the content  of a message related service is not available (into `state.entities.service.byId`).
If `service_id` is undefined and/or the servce is none, the message detail des not displayes the logo, the organization name and the service name (the latters being ""unkown sender/service)

Here  an example after the implementation:
![messageNoServiceAvailable](https://user-images.githubusercontent.com/38431762/63939214-02dd2380-ca67-11e9-8dcc-70ec7adf0575.gif)
