### PR TITLE
[#168195574] Fix device rooted alert translation

### DIFF
--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -3,5 +3,5 @@
     <string name="notification_channel_name">Messaggi</string>
     <string name="notification_channel_description">Ricevi la notifica per i nuovi messaggi</string>
     <string name="alert_device_rooted_title">Dispositivo rootato</string>
-    <string name="alert_device_rooted_desc">Questo dispositivo dispone di permessi di root, non puoi usare questa app</string>
+    <string name="alert_device_rooted_desc">Questo dispositivo dispone di permessi di root, non puoi usare questa app per motivi di sicurezza</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
     <string name="notification_channel_name">Messages</string>
     <string name="notification_channel_description">Receive notification for new messages</string>
     <string name="alert_device_rooted_title">Device rooted</string>
-    <string name="alert_device_rooted_desc">This device is rooted, you can\'t use this app</string>
+    <string name="alert_device_rooted_desc">This device is rooted, you can\'t use this app for security reasons</string>
 </resources>

--- a/ios/ItaliaApp/en.lproj/Localizable.strings
+++ b/ios/ItaliaApp/en.lproj/Localizable.strings
@@ -1,2 +1,2 @@
 "ALERT_DEVICE_ROOTED_TITLE" = "Device jailbroken";
-"ALERT_DEVICE_ROOTED_DESC" = "This device is jailbroken, you can't use this app";
+"ALERT_DEVICE_ROOTED_DESC" = "This device is jailbroken, you can't use this app for security reasons";

--- a/ios/ItaliaApp/it.lproj/Localizable.strings
+++ b/ios/ItaliaApp/it.lproj/Localizable.strings
@@ -1,2 +1,2 @@
 "ALERT_DEVICE_ROOTED_TITLE" = "Dispositivo jailbroken";
-"ALERT_DEVICE_ROOTED_DESC" = "Questo dispositivo dispone di jailbreak, non puoi usare questa app";
+"ALERT_DEVICE_ROOTED_DESC" = "Questo dispositivo dispone di jailbreak, non puoi usare questa app per motivi di sicurezza";


### PR DESCRIPTION
Fixed alert message text.

**iOS:**
<img src="https://user-images.githubusercontent.com/8174240/63951320-d254b400-ca7d-11e9-8398-8c3e7e0e4d38.png" width="40%"> <img src="https://user-images.githubusercontent.com/8174240/64175424-8c239a00-ce5b-11e9-8e23-4aae33113ca9.png" width="40%">

**Android:**
<img src="https://user-images.githubusercontent.com/8174240/63951555-3f684980-ca7e-11e9-9560-5aa31a446658.jpg" width="40%"> <img src="https://user-images.githubusercontent.com/8174240/64175950-b45fc880-ce5c-11e9-838a-66453e0ae116.png" width="45%">

