### PR TITLE
[#168298283] Add timeout to pin clear

### DIFF
--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -162,7 +162,7 @@ class Pinpad extends React.PureComponent<Props, State> {
       const isValid = inputValue === this.props.compareWithCode;
 
       if (!isValid && this.props.clearOnInvalid) {
-        this.clear();
+        setTimeout(() => this.clear(), 100);
         if (this.props.delayOnFailureMillis) {
           // disable click keypad
           this.setState({


### PR DESCRIPTION
This pr introduces a timeout to make the last placeholder being rendered before all the pin placeholders are removed when the user inserts a wrong pin.

BEFORE:
![PinClearBefore](https://user-images.githubusercontent.com/38431762/64622677-fbfbcc80-d3e7-11e9-9405-0a52b5ae697d.gif)


AFTER:
![pinClearTimeout](https://user-images.githubusercontent.com/38431762/64622691-01f1ad80-d3e8-11e9-8530-536c530c7909.gif)
