### PR TITLE
[#168401222] Solves lost reminder mark

### DIFF
--- a/ts/components/messages/CalendarEventButton.tsx
+++ b/ts/components/messages/CalendarEventButton.tsx
@@ -101,17 +101,16 @@ class CalendarEventButton extends React.PureComponent<Props> {
           disabled && disabledStyles.button
         ]}
       >
-        {small && (
-          <IconFont
-            name={iconName}
-            style={[
-              baseStyles.icon,
-              validStyles.icon,
-              small && smallStyles.icon,
-              disabled && disabledStyles.icon
-            ]}
-          />
-        )}
+        <IconFont
+          name={iconName}
+          style={[
+            baseStyles.icon,
+            validStyles.icon,
+            small && smallStyles.icon,
+            disabled && disabledStyles.icon
+          ]}
+        />
+
         <Text
           style={[
             baseStyles.text,


### PR DESCRIPTION
When a reminder is put in calendar, in the message detail screen, the check mark does not appear in the "reminder" button.

|Before                         |After                         |
|-------------------------------|-----------------------------|
|<img width="151" alt="Before_android" src="https://user-images.githubusercontent.com/17931148/64647015-80664380-d418-11e9-97ac-3a4d79d17b44.png">| <img width="151" alt="After_android" src="https://user-images.githubusercontent.com/17931148/64647014-7fcdad00-d418-11e9-9762-0dea6a6b8f2c.png">|
|<img width="151" alt="Before_ios" src="https://user-images.githubusercontent.com/17931148/64647147-c1f6ee80-d418-11e9-9f77-931ff4d5c594.png">|<img width="151" alt="After_ios" src="https://user-images.githubusercontent.com/17931148/64647149-c1f6ee80-d418-11e9-9e26-2f1ea160d17e.png">|



                  
