### PR TITLE
[#168462053] Change "removed payment method" in Transaction Detail screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -362,7 +362,7 @@ wallet:
   delete:
     successful: Card successfully deleted
     failed: The card could not be deleted
-    alert: 'The payment method has been removed from wallet'
+    alert: 'The payment method used for payment of the transaction has been removed from the wallet'
   newPaymentMethod:
     add: add
     addButton: Add a new method

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -362,7 +362,7 @@ wallet:
   delete:
     successful: Card successfully deleted
     failed: The card could not be deleted
-    alert: 'Warning: the payment method has been removed from wallet'
+    alert: 'The payment method has been removed from wallet'
   newPaymentMethod:
     add: add
     addButton: Add a new method

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -369,7 +369,7 @@ wallet:
   delete:
     successful: Carta cancellata correttamente
     failed: Impossibile cancellare la carta
-    alert: 'Attenzione: il metodo di pagamento è stato rimosso dal portafoglio'
+    alert: 'Il metodo di pagamento è stato rimosso dal portafoglio'
   newPaymentMethod:
     add: aggiungi
     addButton: Aggiungi un metodo

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -369,7 +369,7 @@ wallet:
   delete:
     successful: Carta cancellata correttamente
     failed: Impossibile cancellare la carta
-    alert: 'Il metodo di pagamento è stato rimosso dal portafoglio'
+    alert: 'Il metodo di pagamento usato per la transazione non è più presente nel portafoglio'
   newPaymentMethod:
     add: aggiungi
     addButton: Aggiungi un metodo


### PR DESCRIPTION
This PR changes the message displayed in transaction detail screen when the payment method used to pay the transaction is no longer saved into the wallet

### before
<img src="https://user-images.githubusercontent.com/822471/64959080-baa86880-d890-11e9-8cb1-f6e6611268f8.png" height="600"/>

### after
<img src="https://user-images.githubusercontent.com/822471/64959081-baa86880-d890-11e9-9208-a148494c0766.png" height="600"/>
