### PR TITLE
[#168507278] Fix confirm pin

### DIFF
--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -27,6 +27,7 @@ interface Props {
   onCancel?: () => void;
   onPinResetHandler?: () => void;
   onFingerPrintReq?: () => void;
+  onDeleteLastDigit?: () => void;
 }
 
 interface State {
@@ -74,13 +75,17 @@ class Pinpad extends React.PureComponent<Props, State> {
     }
   }
 
-  private deleteLastDigit = () =>
+  private deleteLastDigit = () => {
     this.setState(prev => ({
       value:
         prev.value.length > 0
           ? prev.value.slice(0, prev.value.length - 1)
           : prev.value
     }));
+    if (this.props.onDeleteLastDigit) {
+      this.props.onDeleteLastDigit();
+    }
+  };
 
   private pinPadDigits: ComponentProps<typeof KeyPad>["digits"] = [
     [

--- a/ts/screens/onboarding/PinScreen.tsx
+++ b/ts/screens/onboarding/PinScreen.tsx
@@ -95,12 +95,12 @@ class PinScreen extends React.Component<Props, State> {
   // Method called when the confirmation CodeInput is valid and cancel button is pressed
   public onPinConfirmRemoveLastDigit = () => {
     if (this.state.pinState.state === "PinConfirmed") {
-      const pinSelected: PinSelected = {
+      const pinState: PinSelected = {
         ...this.state.pinState,
         state: "PinSelected"
       };
       this.setState({
-        pinState: pinSelected
+        pinState
       });
     }
   };

--- a/ts/screens/onboarding/PinScreen.tsx
+++ b/ts/screens/onboarding/PinScreen.tsx
@@ -92,6 +92,19 @@ class PinScreen extends React.Component<Props, State> {
       }
     });
 
+  // Method called when the confirmation CodeInput is valid and cancel button is pressed
+  public onPinConfirmRemoveLastDigit = () => {
+    if (this.state.pinState.state === "PinConfirmed") {
+      const pinSelected: PinSelected = {
+        ...this.state.pinState,
+        state: "PinSelected"
+      };
+      this.setState({
+        pinState: pinSelected
+      });
+    }
+  };
+
   // Method called when the confirmation CodeInput is filled
   public onPinConfirmFulfill = (code: PinString, isValid: boolean) => {
     // If the inserted PIN do not match we clear the component to let the user retry
@@ -198,6 +211,7 @@ class PinScreen extends React.Component<Props, State> {
             onFulfill={this.onPinConfirmFulfill}
             ref={pinpad => (this.pinConfirmComponent = pinpad)} // tslint:disable-line no-object-mutation
             buttonType="light"
+            onDeleteLastDigit={this.onPinConfirmRemoveLastDigit}
           />
 
           {this.renderCodeInputConfirmValidation()}


### PR DESCRIPTION
Now once you have entered the correct PIN code for the second time, if you press the "cancel" button, the "continue" button is hidden.


BEFORE:
![before](https://user-images.githubusercontent.com/43071536/65159773-e06e7280-da34-11e9-82e4-9856571c59c3.gif)

AFTER:
![after](https://user-images.githubusercontent.com/43071536/65159797-e82e1700-da34-11e9-8abe-88155ec027cd.gif)


