### PR TITLE
[#168672403] Avoid old organization name is displayed

### DIFF
--- a/ts/sagas/startup/loadServiceRequestHandler.ts
+++ b/ts/sagas/startup/loadServiceRequestHandler.ts
@@ -1,10 +1,21 @@
+import * as pot from "italia-ts-commons/lib/pot";
 import { readableReport } from "italia-ts-commons/lib/reporters";
-import { call, Effect, put } from "redux-saga/effects";
+import { call, Effect, put, select } from "redux-saga/effects";
 import { ActionType } from "typesafe-actions";
 import { BackendClient } from "../../api/backend";
 import { contentServiceLoad } from "../../store/actions/content";
+import { updateOrganizations } from "../../store/actions/organizations";
 import { loadService } from "../../store/actions/services";
+import {
+  organizationNamesByFiscalCodeSelector,
+  OrganizationNamesByFiscalCodeState
+} from "../../store/reducers/entities/organizations/organizationsByFiscalCodeReducer";
+import {
+  visibleServicesSelector,
+  VisibleServicesState
+} from "../../store/reducers/entities/services/visibleServices";
 import { SagaCallReturnType } from "../../types/utils";
+import { isVisibleService } from "../../utils/services";
 
 /**
  * A generator to load the service details from the Backend
@@ -28,6 +39,28 @@ export function* loadServiceRequestHandler(
     }
 
     if (response.value.status === 200) {
+      // If the organization fiscal code is associated to different organizazion names,
+      // it is considered valid the one declared for a visible service
+      const visibleServices: VisibleServicesState = yield select(
+        visibleServicesSelector
+      );
+      const service = pot.some(response.value.value);
+      const isVisible = isVisibleService(visibleServices, service) || false;
+
+      const organizations: OrganizationNamesByFiscalCodeState = yield select(
+        organizationNamesByFiscalCodeSelector
+      );
+      const fc = service.value.organization_fiscal_code;
+
+      if (organizations) {
+        const organization = organizations[fc];
+        // If the organization has been previously saved in the organization entity,
+        // the organization name  is updated only if the related service is visible
+        if (!organization || (organization && isVisible)) {
+          yield put(updateOrganizations(response.value.value));
+        }
+      }
+
       yield put(loadService.success(response.value.value));
 
       // Once the service content is loaded, the service metadata loading is requested.

--- a/ts/store/actions/organizations.ts
+++ b/ts/store/actions/organizations.ts
@@ -2,9 +2,16 @@
  * Action types and action creator related to Organizations.
  */
 import { ActionType, createStandardAction } from "typesafe-actions";
+import { ServicePublic } from "../../../definitions/backend/ServicePublic";
 
 export const setSelectedOrganizations = createStandardAction(
   "SET_SELECTED_ORGANIZATIONS"
 )<ReadonlyArray<string>>();
 
-export type OrganizationsActions = ActionType<typeof setSelectedOrganizations>;
+export const updateOrganizations = createStandardAction("UPDATE_ORGANIZATIONS")<
+  ServicePublic
+>();
+
+export type OrganizationsActions =
+  | ActionType<typeof setSelectedOrganizations>
+  | ActionType<typeof updateOrganizations>;

--- a/ts/store/reducers/entities/organizations/organizationsByFiscalCodeReducer.ts
+++ b/ts/store/reducers/entities/organizations/organizationsByFiscalCodeReducer.ts
@@ -5,7 +5,7 @@
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { getType } from "typesafe-actions";
 
-import { loadService } from "../../../actions/services";
+import { updateOrganizations } from "../../../actions/organizations";
 import { Action } from "../../../actions/types";
 import { GlobalState } from "../../types";
 
@@ -23,7 +23,7 @@ const reducer = (
   action: Action
 ): OrganizationNamesByFiscalCodeState => {
   switch (action.type) {
-    case getType(loadService.success):
+    case getType(updateOrganizations):
       return {
         ...state,
         [action.payload.organization_fiscal_code]:

--- a/ts/utils/services.ts
+++ b/ts/utils/services.ts
@@ -2,11 +2,11 @@
  * Generic utilities for services
  */
 
+import * as pot from "italia-ts-commons/lib/pot";
 import { ImageURISource } from "react-native";
-
 import { ServicePublic } from "../../definitions/backend/ServicePublic";
-
 import { contentRepoUrl } from "../config";
+import { VisibleServicesState } from "../store/reducers/entities/services/visibleServices";
 import { isTextIncludedCaseInsensitive } from "./strings";
 
 /**
@@ -38,3 +38,23 @@ export function serviceContainsText(
     isTextIncludedCaseInsensitive(service.service_name, searchText)
   );
 }
+
+//  Check if the given service is available (visible)
+export const isVisibleService = (
+  visibleServices: VisibleServicesState,
+  potService: pot.Pot<ServicePublic, Error>
+) => {
+  const service = pot.toUndefined(potService);
+  return (
+    service &&
+    pot.getOrElse(
+      pot.map(
+        visibleServices,
+        services =>
+          services.findIndex(item => service.service_id === item.service_id) !==
+          -1
+      ),
+      false
+    )
+  );
+};


### PR DESCRIPTION
This pr introduces a check on the organization_name. Once a service is loaded, the code checks if the corresponding `organization_fiscal_code` exist in the `organization` entity:
- if it does not exist, the pair `organization_fiscal_code` and `organization_name` is stored even if the service is not visible
- if it exists, the `organization_name` associated to the existing `organization_fiscal_code` is updated only if the loaded service is visible.

These changes solve a bug occurring for users having messages sent by a service that is no more available while the same organization has other available services: before these changes, if the no available service is the last loaded for the organization and if it has an old version of the organization name, the app displays the old organization name.