### PR TITLE
[#168991871] Clear municipality metadata at startup

### DIFF
--- a/ts/screens/profile/FiscalCodeScreen.tsx
+++ b/ts/screens/profile/FiscalCodeScreen.tsx
@@ -74,17 +74,8 @@ class FiscalCodeScreen extends React.PureComponent<Props> {
       const maybeCodiceCatastale = CodiceCatastale.decode(
         this.props.profile.fiscal_code.substring(11, 15)
       );
-      // if the maybeCodiceCatastale stored value is different from the requiring one
-      // we need to ask for an update
-      const isNeededToUpdate = pot.getOrElse(
-        pot.map(
-          this.props.municipality.codiceCatastale,
-          c =>
-            maybeCodiceCatastale.isRight() && maybeCodiceCatastale.value !== c
-        ),
-        true
-      );
-      if (pot.isNone(this.props.municipality.data) || isNeededToUpdate) {
+      // if municipality data are none we request a load
+      if (pot.isNone(this.props.municipality.data)) {
         maybeCodiceCatastale.map(c => this.props.loadMunicipality(c));
       }
     }

--- a/ts/store/reducers/content.ts
+++ b/ts/store/reducers/content.ts
@@ -103,8 +103,8 @@ export default function content(
       return {
         ...state,
         municipality: {
-          codiceCatastale: pot.none,
-          data: pot.none
+          codiceCatastale: pot.noneLoading,
+          data: pot.noneLoading
         }
       };
 

--- a/ts/store/reducers/content.ts
+++ b/ts/store/reducers/content.ts
@@ -132,7 +132,8 @@ export default function content(
     case getType(clearCache):
       return {
         ...state,
-        servicesMetadata: { ...initialContentState.servicesMetadata }
+        servicesMetadata: { ...initialContentState.servicesMetadata },
+        municipality: { ...initialContentState.municipality }
       };
 
     case getType(removeServiceTuples): {


### PR DESCRIPTION
This PR fixes a wrong implementation done here https://github.com/teamdigitale/io-app/pull/1356

Now the municipality metadata will be deleted at startup when (if) the current profile has a cf different from the previous one