### PR TITLE
[#169311321] From department to service on message list item

### DIFF
--- a/ts/components/messages/MessageListItem.tsx
+++ b/ts/components/messages/MessageListItem.tsx
@@ -1,8 +1,10 @@
+/**
+ * A component to display the list item in the MessageHomeScreen
+ */
 import { fromNullable } from "fp-ts/lib/Option";
 import { Button, Text, View } from "native-base";
 import React from "react";
 import { Platform, StyleSheet, TouchableOpacity } from "react-native";
-
 import { CreatedMessageWithContent } from "../../../definitions/backend/CreatedMessageWithContent";
 import { ServicePublic } from "../../../definitions/backend/ServicePublic";
 import I18n from "../../i18n";
@@ -117,7 +119,7 @@ const styles = StyleSheet.create({
 
 const UNKNOWN_SERVICE_DATA = {
   organizationName: I18n.t("messages.errorLoading.senderInfo"),
-  departmentName: I18n.t("messages.errorLoading.serviceInfo")
+  serviceName: I18n.t("messages.errorLoading.serviceInfo")
 };
 
 class MessageListItem extends React.PureComponent<Props> {
@@ -141,7 +143,7 @@ class MessageListItem extends React.PureComponent<Props> {
 
     const uiService = fromNullable(service).fold(UNKNOWN_SERVICE_DATA, _ => ({
       organizationName: _.organization_name,
-      departmentName: _.department_name
+      serviceName: _.service_name
     }));
 
     const uiDate = convertDateToWordDistance(
@@ -173,7 +175,7 @@ class MessageListItem extends React.PureComponent<Props> {
                 {uiService.organizationName}
               </Text>
               <Text numberOfLines={1} style={styles.serviceDepartmentName}>
-                {uiService.departmentName}
+                {uiService.serviceName}
               </Text>
             </View>
             <View style={styles.headerRight}>


### PR DESCRIPTION
This pr updates the message list item to display, under the name of the organization, the service name  instead of the department name

<img width="545" alt="image" src="https://user-images.githubusercontent.com/38431762/67373500-05985880-f580-11e9-8cdf-8d24fbdf4a8a.png">
