### PR TITLE
[#169347578] Fix error forwarding on deleteWalletRequestHandler

### DIFF
--- a/ts/sagas/wallet/pagopaApis.ts
+++ b/ts/sagas/wallet/pagopaApis.ts
@@ -326,7 +326,7 @@ export function* deleteWalletRequestHandler(
       );
     }
   } catch (e) {
-    const failureAction = deleteWalletFailure(e.message);
+    const failureAction = deleteWalletFailure(e);
     yield put(failureAction);
     if (action.payload.onFailure) {
       action.payload.onFailure(failureAction);


### PR DESCRIPTION
This PR fixes a bug inside deleteWalletRequestHandler where the action **deleteWalletFailure** is called with a wrong parameter (a string instead of the Error object)