### PR TITLE
[#169017205] Order reducers in store index file

### DIFF
--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -64,15 +64,13 @@ const appReducer: Reducer<GlobalState, Action> = combineReducers<
   network: networkReducer,
   nav: navigationReducer,
   deepLink: deepLinkReducer,
-  installation: installationReducer,
   wallet: walletReducer,
   backendInfo: backendInfoReducer,
-  content: contentReducer,
   preferences: preferencesReducer,
-  persistedPreferences: persistedPreferencesReducer,
   identification: identificationReducer,
   navigationHistory: navigationHistoryReducer,
   instabug: instabugUnreadMessagesReducer,
+  search: searchReducer,
 
   //
   // persisted state
@@ -91,8 +89,10 @@ const appReducer: Reducer<GlobalState, Action> = combineReducers<
   userMetadata: userMetadataReducer,
   entities: entitiesReducer,
   debug: debugReducer,
-  search: searchReducer,
-  payments: paymentsReducer
+  persistedPreferences: persistedPreferencesReducer,
+  installation: installationReducer,
+  payments: paymentsReducer,
+  content: contentReducer
 });
 
 export function createRootReducer(


### PR DESCRIPTION
This pr introduces a small fix on the order the reducers are listed in the `appReducer` item to get:
- not persisted states are listed under the `ephemeral state` comment
- persisted states are listed under the `persisted state` comment