### PR TITLE
[#169732720] Added missing iOS permission

### DIFF
--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -52,6 +52,8 @@
 	</dict>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>The app needs NSBluetoothPeripheralUsageDescription permission</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>The app needs NSBluetoothAlwaysUsageDescription permission</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>IO needs access to the calendar to add event reminders</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
The **NSBluetoothAlwaysUsageDescription** permission is mandatory if an app (including dependencies) uses the Bluetooth API*.
In older iOS versions it was called **NSBluetoothPeripheralUsageDescription** and it is already present in the Info.plist but it has been replaced with NSBluetoothAlwaysUsageDescription in iOS 13; since the app targets an earlier iOS version both permissions are required.

<sub>*_the API is used by the library react-native-community/react-native-permissions_</sub>

[Apple documentation reference](https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothperipheralusagedescription) 