### PR TITLE
[#169424936] added LoadingScreen & new loading route

### DIFF
--- a/ts/navigation/OnboardingNavigator.ts
+++ b/ts/navigation/OnboardingNavigator.ts
@@ -1,5 +1,6 @@
 import { createStackNavigator } from "react-navigation";
 
+import LoadingScreen from "../screens/LoadingScreen";
 import EmailInsertScreen from "../screens/onboarding/EmailInsertScreen";
 import EmailReadScreen from "../screens/onboarding/EmailReadScreen";
 import EmailValidateScreen from "../screens/onboarding/EmailValidateScreen";
@@ -30,6 +31,9 @@ const navigator = createStackNavigator(
     },
     [ROUTES.READ_EMAIL_SCREEN]: {
       screen: EmailReadScreen
+    },
+    [ROUTES.LOADING]: {
+      screen: LoadingScreen
     }
   },
   {

--- a/ts/navigation/routes.ts
+++ b/ts/navigation/routes.ts
@@ -84,7 +84,10 @@ const ROUTES = {
   INSERT_EMAIL_SCREEN: "INSERT_EMAIL_SCREEN",
 
   // Used when the App is in background
-  BACKGROUND: "BACKGROUND"
+  BACKGROUND: "BACKGROUND",
+
+  // Loading screen
+  LOADING: "LOADING"
 };
 
 export default ROUTES;

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -28,6 +28,7 @@ import { sessionExpired } from "../store/actions/authentication";
 import { previousInstallationDataDeleteSuccess } from "../store/actions/installation";
 import { loadMessageWithRelations } from "../store/actions/messages";
 import {
+  navigateToLoadingScreen,
   navigateToMainNavigatorAction,
   navigateToMessageDetailScreenAction
 } from "../store/actions/navigation";
@@ -258,6 +259,10 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
       yield cancel(watchAbortOnboardingSagaTask);
     }
   }
+
+  //
+  // Navigate to the LoadingScreen
+  yield put(navigateToLoadingScreen);
 
   //
   // User is autenticated, session token is valid

--- a/ts/screens/LoadingScreen.tsx
+++ b/ts/screens/LoadingScreen.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { View } from "react-native";
+import LoadingSpinnerOverlay from "../components/LoadingSpinnerOverlay";
+import BaseScreenComponent from "../components/screens/BaseScreenComponent";
+
+interface State {
+  isLoading: boolean;
+}
+/**
+ * A loading screen used during the saga startup process to display a Spinner
+ * until all the saga are performed, including the navigation in the message screen
+ */
+class LoadingScreen extends React.PureComponent<never, State> {
+  constructor(props: never) {
+    super(props);
+    this.state = {
+      isLoading: true
+    };
+  }
+  public componentWillUnmount() {
+    this.setState({ isLoading: false });
+  }
+
+  public render() {
+    const { isLoading } = this.state;
+    return (
+      <BaseScreenComponent appLogo={true}>
+        <LoadingSpinnerOverlay isLoading={isLoading} loadingOpacity={1}>
+          <View />
+        </LoadingSpinnerOverlay>
+      </BaseScreenComponent>
+    );
+  }
+}
+
+export default LoadingScreen;

--- a/ts/store/actions/navigation.ts
+++ b/ts/store/actions/navigation.ts
@@ -80,6 +80,11 @@ export const navigateToTosScreen = NavigationActions.navigate({
   action: NavigationActions.navigate({ routeName: ROUTES.ONBOARDING_TOS })
 });
 
+export const navigateToLoadingScreen = NavigationActions.navigate({
+  routeName: ROUTES.LOADING,
+  action: NavigationActions.navigate({ routeName: ROUTES.LOADING })
+});
+
 export const navigateToEmailValidateScreen = NavigationActions.navigate({
   routeName: ROUTES.ONBOARDING,
   action: NavigationActions.navigate({


### PR DESCRIPTION
This PR adds a loading screen during the saga startup process to display until all the saga are performed

![loading-onboarding](https://user-images.githubusercontent.com/2670647/69418569-3e605480-0d1b-11ea-8111-b9028d02f908.gif)
