### PR TITLE
[#170014542] Fix data extraction from cf

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at . All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/ts/utils/__tests__/profile.test.ts
+++ b/ts/utils/__tests__/profile.test.ts
@@ -1,0 +1,67 @@
+import { none, some } from "italia-ts-commons/lib/pot";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { Municipality } from "../../../definitions/content/Municipality";
+import { extractFiscalCodeData } from "../profile";
+
+describe("extracting data from fiscal code", () => {
+  // mario rossi / roma / rm / 1-1-1980
+  const goodCf = "RSSMRA80A01H501U" as FiscalCode;
+  const goodMunicipality: Municipality = {
+    codiceProvincia: "091",
+    codiceRegione: "12",
+    denominazione: "Roma",
+    denominazioneInItaliano: "Roma",
+    denominazioneRegione: "Lazio",
+    siglaProvincia: "RM"
+  };
+  const potGood = some(goodMunicipality);
+  const data = extractFiscalCodeData(goodCf, potGood);
+  it("should return the extracted data", () => {
+    expect(data.birthDate).toBeDefined();
+    expect(data.birthDate).toEqual("01/01/1980");
+    expect(data.gender).toEqual("M");
+    expect(data.denominazione).toEqual("Roma");
+    expect(data.siglaProvincia).toEqual("RM");
+  });
+
+  const wrongCf = "RSSMRA80A0RH501U" as FiscalCode;
+  const dataWrong1 = extractFiscalCodeData(wrongCf, potGood);
+  it("should return the extracted data without birth information", () => {
+    expect(dataWrong1.birthDate).not.toBeDefined();
+    expect(data.gender).toEqual("M");
+    expect(data.denominazione).toEqual("Roma");
+    expect(data.siglaProvincia).toEqual("RM");
+  });
+
+  // giulia rossi / roma / rm / 12-07-1956
+  const goodCfF = "GLIRSS56L52H501P" as FiscalCode;
+  const dataF = extractFiscalCodeData(goodCfF, potGood);
+  it("should recognize the female sex", () => {
+    expect(dataF.birthDate).toBeDefined();
+    expect(dataF.birthDate).toEqual("12/07/1956");
+    expect(dataF.gender).toEqual("F");
+    expect(dataF.denominazione).toEqual("Roma");
+    expect(dataF.siglaProvincia).toEqual("RM");
+  });
+
+  // giulia rossi / roma / rm / 12-07-2003
+  const goodCfF2 = "GLIRSS03L52H501A" as FiscalCode;
+  const dataF2 = extractFiscalCodeData(goodCfF2, potGood);
+  it("should recognize the 2003", () => {
+    expect(dataF2.birthDate).toBeDefined();
+    expect(dataF2.birthDate).toEqual("12/07/2003");
+    expect(dataF2.gender).toEqual("F");
+    expect(dataF2.denominazione).toEqual("Roma");
+    expect(dataF2.siglaProvincia).toEqual("RM");
+  });
+
+  // giulia rossi / roma / rm / 12-07-2003
+  const dataNoM = extractFiscalCodeData(goodCfF2, none);
+  it("should return birth place empty", () => {
+    expect(dataNoM.birthDate).toBeDefined();
+    expect(dataNoM.birthDate).toEqual("12/07/2003");
+    expect(dataNoM.gender).toEqual("F");
+    expect(dataNoM.denominazione).toEqual("");
+    expect(dataNoM.siglaProvincia).toEqual("");
+  });
+});

--- a/ts/utils/__tests__/profile.test.ts
+++ b/ts/utils/__tests__/profile.test.ts
@@ -47,7 +47,7 @@ describe("extracting data from fiscal code", () => {
   // giulia rossi / roma / rm / 12-07-2003
   const goodCfF2 = "GLIRSS03L52H501A" as FiscalCode;
   const dataF2 = extractFiscalCodeData(goodCfF2, potGood);
-  it("should recognize the 2003", () => {
+  it("should recognize the 2003 as year of birth", () => {
     expect(dataF2.birthDate).toBeDefined();
     expect(dataF2.birthDate).toEqual("12/07/2003");
     expect(dataF2.gender).toEqual("F");

--- a/ts/utils/profile.ts
+++ b/ts/utils/profile.ts
@@ -47,7 +47,8 @@ export function extractFiscalCodeData(
     pot.map(municipality, m => m.denominazioneInItaliano),
     ""
   );
-  // if we can know more about date of birth
+  // if we can't know more about date of birth
+  // just return info about municipality
   if (!RegExp("^[0-9]+$").test(fiscalCode.substring(9, 11))) {
     return {
       siglaProvincia,
@@ -57,7 +58,6 @@ export function extractFiscalCodeData(
 
   const tempDay = parseInt(fiscalCode.substring(9, 11), 10);
   const gender = tempDay - 40 > 0 ? "F" : "M";
-
   const month = months[fiscalCode.charAt(8)];
 
   if (
@@ -75,12 +75,12 @@ export function extractFiscalCodeData(
   const tempYear = parseInt(fiscalCode.substring(6, 8), 10);
   // to avoid the century date collision (01 could mean 1901 or 2001)
   // we assume that if the birth date is grater than a century, the date
-  // referrs to the new century
+  // refers to the new century
   const year =
     tempYear +
     (new Date().getFullYear() - (1900 + tempYear) >= 100 ? 2000 : 1900);
   const birthDate = format(
-    new Date(year, month - 1, day), // months are indexed from index 0
+    new Date(year, month - 1, day), // months are 0-index
     "DD/MM/YYYY"
   );
 


### PR DESCRIPTION
This PR fixes the century extraction from CF:

the year of birth is represented by 2 digit (index 6-7) into the cf

ex: GLIRSS**03**L52H501A

03 could mean 1903 or 2003
The fix consist to check if the computed year is greater than a century. In that case we could assume the year is referring to someone born in the 2000