### PR TITLE
[#170315020] Fix pin insertion while biometric is requesting

### DIFF
--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -402,7 +402,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
             identificationByBiometryState: "failure"
           });
         } else {
-          // it the user dismissed the biometric dialog, unlock the pin insertion
+          // if the user dismissed the biometric dialog, unlock the pin insertion
           this.setState({
             canInsertPin: true
           });

--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -42,6 +42,7 @@ type State = {
   identificationByPinState: IdentificationByPinState;
   identificationByBiometryState: IdentificationByBiometryState;
   biometryType?: BiometryPrintableSimpleType;
+  canInsertPin: boolean;
 };
 
 const contextualHelp = {
@@ -120,13 +121,13 @@ class IdentificationModal extends React.PureComponent<Props, State> {
 
     this.state = {
       identificationByPinState: "unstarted",
-      identificationByBiometryState: "unstarted"
+      identificationByBiometryState: "unstarted",
+      canInsertPin: false
     };
   }
 
   public componentWillMount() {
     const { isFingerprintEnabled } = this.props;
-
     if (isFingerprintEnabled) {
       getFingerprintSettings().then(
         biometryType =>
@@ -138,6 +139,9 @@ class IdentificationModal extends React.PureComponent<Props, State> {
           }),
         _ => 0
       );
+    } else {
+      // if the biometric is not available unlock the pin insertion
+      this.setState({ canInsertPin: true });
     }
   }
 
@@ -175,7 +179,10 @@ class IdentificationModal extends React.PureComponent<Props, State> {
                   biometryType !== "NOT_ENROLLED" &&
                   biometryType !== "UNAVAILABLE"
                     ? biometryType
-                    : undefined
+                    : undefined,
+                canInsertPin:
+                  biometryType === "NOT_ENROLLED" ||
+                  biometryType === "UNAVAILABLE"
               });
             }
           },
@@ -301,6 +308,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
                   this.onIdentificationFailureHandler
                 )
               }
+              disabled={!this.state.canInsertPin}
               compareWithCode={pin as string}
               activeColor={"white"}
               inactiveColor={"white"}
@@ -392,6 +400,11 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         ) {
           this.setState({
             identificationByBiometryState: "failure"
+          });
+        } else {
+          // it the user dismissed the biometric dialog, unlock the pin insertion
+          this.setState({
+            canInsertPin: true
           });
         }
         onIdentificationFailureHandler();

--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -191,7 +191,7 @@ const logger = createLogger({
 });
 
 // configure Reactotron if the app is running in dev mode
-const RTron = __DEV__ ? configureReactotron() : {};
+export const RTron = __DEV__ ? configureReactotron() : {};
 const sagaMiddleware = createSagaMiddleware(
   __DEV__ ? { sagaMonitor: RTron.createSagaMonitor() } : {}
 );

--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -163,7 +163,7 @@ class Pinpad extends React.PureComponent<Props, State> {
 
   private handleChangeText = (inputValue: string) => {
     // if the component is disabled don't handle any input
-    if (this.props.disabled === true) {
+    if (this.props.disabled) {
       return;
     }
     this.setState({ value: inputValue });

--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   biometryType?: any;
   compareWithCode?: string;
   inactiveColor: string;
+  disabled?: boolean;
   buttonType: ComponentProps<typeof KeyPad>["buttonType"];
   onFulfill: (code: PinString, isValid: boolean) => void;
   onCancel?: () => void;
@@ -161,6 +162,10 @@ class Pinpad extends React.PureComponent<Props, State> {
   }
 
   private handleChangeText = (inputValue: string) => {
+    // if the component is disabled don't handle any input
+    if (this.props.disabled === true) {
+      return;
+    }
     this.setState({ value: inputValue });
 
     // Pin is fulfilled


### PR DESCRIPTION
**Short description:**
This PR fixes a security bug on the identification phase.

**List of changes proposed in this pull request:**
- Avoid PIN insertion while biometric is requesting

**How to test:**
On Identification screen try to insert some pin digitis before the biometric dialog is displayed. The pin digits should be discarded