### PR TITLE
[#170402537] Fix crash on ConfirmPaymentMethodScreen

### DIFF
--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -183,14 +183,12 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
               {maybeWalletFee.isSome() && (
                 <Row>
                   <Col size={4}>
-                    <Text>
-                      {`${I18n.t("wallet.ConfirmPayment.fee")} `}
-                      <TouchableDefaultOpacity onPress={this.showHelp}>
-                        <Text link={true}>
-                          {I18n.t("wallet.ConfirmPayment.why")}
-                        </Text>
-                      </TouchableDefaultOpacity>
-                    </Text>
+                    <Text>{`${I18n.t("wallet.ConfirmPayment.fee")} `}</Text>
+                    <TouchableDefaultOpacity onPress={this.showHelp}>
+                      <Text link={true}>
+                        {I18n.t("wallet.ConfirmPayment.why")}
+                      </Text>
+                    </TouchableDefaultOpacity>
                   </Col>
 
                   <Col size={1}>
@@ -234,10 +232,10 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
                           wallet.psp.businessName
                         } `
                       : I18n.t("payment.noPsp")}
-                    <TouchableDefaultOpacity onPress={this.props.pickPsp}>
-                      <Text link={true}>{I18n.t("payment.changePsp")}</Text>
-                    </TouchableDefaultOpacity>
                   </Text>
+                  <TouchableDefaultOpacity onPress={this.props.pickPsp}>
+                    <Text link={true}>{I18n.t("payment.changePsp")}</Text>
+                  </TouchableDefaultOpacity>
                   <View spacer={true} />
                 </Col>
                 <Col size={1} />


### PR DESCRIPTION
**Short description:**
This PRs fixes a crash that happens when user navigates on ConfirmPaymentMethodScreen

**List of changes proposed in this pull request:**
Removed unsupported nested views
Maybe this bug is related to this https://github.com/teamdigitale/io-app/pull/1259

**How to test:**
Try for a payment. 