### PR TITLE
[#169067698] fix loading potService in messageList

### DIFF
--- a/ts/components/messages/MessageList.tsx
+++ b/ts/components/messages/MessageList.tsx
@@ -227,6 +227,7 @@ class MessageList extends React.Component<Props, State> {
     const potService = this.props.servicesById[meta.sender_service_id];
     if (
       potService &&
+      !pot.isSome(potService) &&
       (pot.isLoading(potService) || pot.isLoading(potMessage))
     ) {
       return MessageListItemPlaceholder;

--- a/ts/components/messages/MessageList.tsx
+++ b/ts/components/messages/MessageList.tsx
@@ -225,11 +225,10 @@ class MessageList extends React.Component<Props, State> {
     const { paymentsByRptId, onPressItem } = this.props;
 
     const potService = this.props.servicesById[meta.sender_service_id];
-    if (
-      potService &&
-      !pot.isSome(potService) &&
-      (pot.isLoading(potService) || pot.isLoading(potMessage))
-    ) {
+    const isServiceLoading = potService
+      ? pot.isNone(potService) && pot.isLoading(potService) // is none loading
+      : false;
+    if (isServiceLoading || pot.isLoading(potMessage)) {
       return MessageListItemPlaceholder;
     }
 


### PR DESCRIPTION
this PR allows you to display, if present, the service previously loaded while it is being refreshed.


![loading-service-message](https://user-images.githubusercontent.com/2670647/71278165-18989080-2357-11ea-82c2-3005d7b90b5b.gif)
