### PR TITLE
[#169224694] fix reminders.loadMoreData locales

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -827,7 +827,7 @@ calendarEvents:
     cancel: Cancel the operation
 reminders:
   emptyMonth: No reminders for this month
-  loadMoreData: loads the deadlines of the previous period
+  loadMoreData: previous deadlines
   email:
     title: Remember to validate your email address
     modal1: "Some functionalities of IO require you validate your email address. \n We sent an email to"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -837,7 +837,7 @@ calendarEvents:
     cancel: Annulla l'operazione
 reminders:
   emptyMonth: Non ci sono scadenze in questo mese
-  loadMoreData: carica le scadenze del periodo precedente
+  loadMoreData: scadenze precedenti
   email:
     title: Ricorda di validare il tuo indirizzo email
     modal1: "Per usare alcune funzioni di IO devi validare il tuo indirizzo email. \n Ti abbiamo inviato una email a"


### PR DESCRIPTION
this PR changes the locales 'reminders.loadMoreData':

* it
  * before: carica le scadenze del periodo precedente
  * now: scadenze precedenti
* en
  * before: loads the deadlines of the previous period
  * now previous deadlines