### PR TITLE
[#168138829] fix pay notice button

### DIFF
--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -354,7 +354,8 @@ class WalletHomeScreen extends React.Component<Props, never> {
       ? this.transactionError()
       : this.transactionList(potTransactions);
 
-    const footerContent = this.footerButton(potWallets);
+    const footerContent =
+      pot.isSome(potWallets) && this.footerButton(potWallets);
 
     const walletRefreshControl = (
       <RefreshControl


### PR DESCRIPTION
This PR make the footer button visible only when wallets are successfully loaded

![paynotice-loading](https://user-images.githubusercontent.com/2670647/71974704-790e4580-3212-11ea-9c3b-b74da98c835d.gif)
