### PR TITLE
[#169541951] Minor updates to idp selection code

### DIFF
--- a/ts/components/IdpSuccessfulAuthentication.tsx
+++ b/ts/components/IdpSuccessfulAuthentication.tsx
@@ -1,3 +1,6 @@
+/**
+ * A component to diplay a white tick on a blue background
+ */
 import { View } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";

--- a/ts/components/IdpSuccessfulAuthentication.tsx
+++ b/ts/components/IdpSuccessfulAuthentication.tsx
@@ -1,5 +1,5 @@
 /**
- * A component to diplay a white tick on a blue background
+ * A component to display a white tick on a blue background
  */
 import { View } from "native-base";
 import * as React from "react";

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -37,7 +37,7 @@ enum ErrorType {
 }
 
 type State = {
-  requestState: pot.Pot<true, ErrorType.LOADING_ERROR | ErrorType.LOGIN_ERROR>;
+  requestState: pot.Pot<true, ErrorType>;
   errorCode?: string;
   loginTrace?: string;
 };

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -1,20 +1,23 @@
+/**
+ * A screen that allow the user to login with an IDP.
+ * The IDP page is opened in a WebView
+ */
+import * as pot from "italia-ts-commons/lib/pot";
 import { Text, View } from "native-base";
 import * as React from "react";
 import { Image, NavState, StyleSheet } from "react-native";
 import { WebView } from "react-native-webview";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps } from "react-navigation";
 import { connect } from "react-redux";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
-
-import { idpLoginUrlChanged } from "../../store/actions/authentication";
-
-import * as pot from "italia-ts-commons/lib/pot";
 import { IdpSuccessfulAuthentication } from "../../components/IdpSuccessfulAuthentication";
+import LoadingSpinnerOverlay from "../../components/LoadingSpinnerOverlay";
 import BaseScreenComponent from "../../components/screens/BaseScreenComponent";
 import { RefreshIndicator } from "../../components/ui/RefreshIndicator";
 import * as config from "../../config";
 import I18n from "../../i18n";
 import { loginFailure, loginSuccess } from "../../store/actions/authentication";
+import { idpLoginUrlChanged } from "../../store/actions/authentication";
 import { Dispatch } from "../../store/actions/types";
 import {
   isLoggedIn,
@@ -24,17 +27,19 @@ import { GlobalState } from "../../store/reducers/types";
 import { SessionToken } from "../../types/SessionToken";
 import { extractLoginResult } from "../../utils/login";
 
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
-
-type Props = ReturnType<typeof mapStateToProps> &
-  OwnProps &
+type Props = NavigationScreenProps &
+  ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
 
+enum ErrorType {
+  "LOADING_ERROR" = "LOADING_ERROR",
+  "LOGIN_ERROR" = "LOGIN_ERROR"
+}
+
 type State = {
-  requestState: pot.Pot<true, "LOADING_ERROR" | "LOGIN_ERROR">;
+  requestState: pot.Pot<true, ErrorType.LOADING_ERROR | ErrorType.LOGIN_ERROR>;
   errorCode?: string;
+  loginTrace?: string;
 };
 
 const LOGIN_BASE_URL = `${
@@ -110,13 +115,7 @@ const onNavigationStateChange = (
   return false;
 };
 
-/**
- * A screen that allow the user to login with an IDP.
- * The IDP page is opened in a WebView
- */
 class IdpLoginScreen extends React.Component<Props, State> {
-  private loginTrace?: string;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -125,13 +124,12 @@ class IdpLoginScreen extends React.Component<Props, State> {
   }
 
   private updateLoginTrace = (url: string): void => {
-    // tslint:disable-next-line: no-object-mutation
-    this.loginTrace = url;
+    this.setState({ loginTrace: url });
   };
 
   private handleLoadingError = (): void => {
     this.setState({
-      requestState: pot.noneError("LOADING_ERROR")
+      requestState: pot.noneError(ErrorType.LOADING_ERROR)
     });
   };
 
@@ -140,7 +138,7 @@ class IdpLoginScreen extends React.Component<Props, State> {
       new Error(`login failure with code ${errorCode || "n/a"}`)
     );
     this.setState({
-      requestState: pot.noneError("LOGIN_ERROR"),
+      requestState: pot.noneError(ErrorType.LOGIN_ERROR),
       errorCode
     });
   };
@@ -151,7 +149,7 @@ class IdpLoginScreen extends React.Component<Props, State> {
     this.setState({ requestState: pot.noneLoading });
 
   private handleNavigationStateChange = (event: NavState): void => {
-    if (event.url && event.url !== this.loginTrace) {
+    if (event.url && event.url !== this.state.loginTrace) {
       const urlChanged = event.url.split("?")[0];
       this.props.dispatchIdpLoginUrlChanged(urlChanged);
       this.updateLoginTrace(urlChanged);
@@ -189,13 +187,13 @@ class IdpLoginScreen extends React.Component<Props, State> {
           <Image source={brokenLinkImage} resizeMode="contain" />
           <Text style={styles.errorTitle} bold={true}>
             {I18n.t(
-              errorType === "LOADING_ERROR"
+              errorType === ErrorType.LOADING_ERROR
                 ? "authentication.errors.network.title"
                 : "authentication.errors.login.title"
             )}
           </Text>
 
-          {errorType === "LOGIN_ERROR" && (
+          {errorType === ErrorType.LOGIN_ERROR && (
             <Text style={styles.errorBody}>
               {I18n.t(errorTranslationKey, {
                 defaultValue: I18n.t("authentication.errors.spid.unknown")
@@ -238,9 +236,9 @@ class IdpLoginScreen extends React.Component<Props, State> {
     }
 
     if (!loggedOutWithIdpAuth) {
-      // FIXME: perhaps as a safe bet, navigate to the IdP selection screen on mount?
-      //      https://www.pivotaltracker.com/story/show/169541951
-      return null;
+      // This condition will be true only temporarily (if the navigation occurs
+      // before the redux state is updated succesfully)
+      return <LoadingSpinnerOverlay isLoading={true} />;
     }
     const loginUri = LOGIN_BASE_URL + loggedOutWithIdpAuth.idp.entityID;
     return (

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -1,5 +1,5 @@
 /**
- * A screen that allow the user to login with an IDP.
+ * A screen that allows the user to login with an IDP.
  * The IDP page is opened in a WebView
  */
 import * as pot from "italia-ts-commons/lib/pot";


### PR DESCRIPTION
**Short description:**
This pr introduces some updates to the screens related to the idp selection

**List of changes proposed in this pull request:**
- Add comment to describe the `IdpSuccessfulAuthentication` component
- `IdpLoginScreen`:
  - shift comment to the top of the screen
  - use an enum instead of strings as values of the component state `requestState`
  - [MAIN CHANGE]`loggedOutWithIdpAuth`: this state should be always true, having that the corresponding redux state is updated slightly before the app navigates from `IdpSelectionScreen` to this screen. The redux state update process is an async process, so, in the remote case its update takes a longer time, instead of returning a null object (implying a white screen is displayed), we could display a Loader as the following
![Loader](https://user-images.githubusercontent.com/38431762/72147709-6d9c5500-339f-11ea-9cc3-833b92751b92.gif)
