### PR TITLE
[#170679956] reset selection when change tab

### DIFF
--- a/ts/components/messages/MessagesArchive.tsx
+++ b/ts/components/messages/MessagesArchive.tsx
@@ -45,6 +45,7 @@ const styles = StyleSheet.create({
 });
 
 type OwnProps = {
+  currentTab: number;
   messagesState: ReturnType<typeof lexicallyOrderedMessagesStateSelector>;
   navigateToMessageDetail: (id: string) => void;
   setMessagesArchivedState: (
@@ -136,6 +137,12 @@ class MessagesArchive extends React.PureComponent<Props, State> {
 
     // The state must not be changed.
     return null;
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (prevProps.currentTab !== this.props.currentTab) {
+      this.props.resetSelection();
+    }
   }
 
   constructor(props: Props) {

--- a/ts/components/messages/MessagesDeadlines.tsx
+++ b/ts/components/messages/MessagesDeadlines.tsx
@@ -51,6 +51,7 @@ const styles = StyleSheet.create({
 });
 
 type OwnProps = {
+  currentTab: number;
   messagesState: ReturnType<typeof lexicallyOrderedMessagesStateSelector>;
   navigateToMessageDetail: (id: string) => void;
   setMessagesArchivedState: (
@@ -456,6 +457,10 @@ class MessagesDeadlines extends React.PureComponent<Props, State> {
     const { messagesState } = this.props;
     const { messagesState: prevMessagesState } = prevProps;
     const { maybeLastLoadedStartOfMonthTime } = this.state;
+
+    if (prevProps.currentTab !== this.props.currentTab) {
+      this.props.resetSelection();
+    }
 
     if (messagesState !== prevMessagesState) {
       this.setState({

--- a/ts/components/messages/MessagesInbox.tsx
+++ b/ts/components/messages/MessagesInbox.tsx
@@ -45,6 +45,7 @@ const styles = StyleSheet.create({
 });
 
 type OwnProps = {
+  currentTab: number;
   messagesState: ReturnType<typeof lexicallyOrderedMessagesStateSelector>;
   navigateToMessageDetail: (id: string) => void;
   setMessagesArchivedState: (
@@ -149,6 +150,12 @@ class MessagesInbox extends React.PureComponent<Props, State> {
       filteredMessageStates: [],
       allMessageIdsState: none
     };
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (prevProps.currentTab !== this.props.currentTab) {
+      this.props.resetSelection();
+    }
   }
 
   public render() {

--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -177,6 +177,23 @@ class MessagesHomeScreen extends React.Component<Props, State> {
     );
   }
 
+  private handleOnScroll = (value: number) => {
+    const { currentTab } = this.state;
+    if (Math.abs(value - currentTab) > 0.5) {
+      const nextTab = currentTab + (value - currentTab > 0 ? 1 : -1);
+      this.setState({
+        currentTab: nextTab
+      });
+    }
+  };
+
+  private handleOnChangeTab = (evt: any) => {
+    const nextTab: number = evt.i;
+    this.setState({
+      currentTab: nextTab
+    });
+  };
+
   /**
    * Render Inbox, Deadlines and Archive tabs.
    */
@@ -193,9 +210,8 @@ class MessagesHomeScreen extends React.Component<Props, State> {
       <AnimatedTabs
         tabContainerStyle={[styles.tabBarContainer, styles.tabBarUnderline]}
         tabBarUnderlineStyle={styles.tabBarUnderlineActive}
-        onChangeTab={(evt: any) => {
-          this.setState({ currentTab: evt.i });
-        }}
+        onScroll={this.handleOnScroll}
+        onChangeTab={this.handleOnChangeTab}
         initialPage={0}
         style={{
           transform: [
@@ -225,6 +241,7 @@ class MessagesHomeScreen extends React.Component<Props, State> {
           heading={I18n.t("messages.tab.inbox")}
         >
           <MessagesInbox
+            currentTab={this.state.currentTab}
             messagesState={lexicallyOrderedMessagesState}
             servicesById={servicesById}
             paymentsByRptId={paymentsByRptId}
@@ -273,6 +290,7 @@ class MessagesHomeScreen extends React.Component<Props, State> {
           heading={I18n.t("messages.tab.deadlines")}
         >
           <MessagesDeadlines
+            currentTab={this.state.currentTab}
             messagesState={lexicallyOrderedMessagesState}
             servicesById={servicesById}
             paymentsByRptId={paymentsByRptId}
@@ -287,6 +305,7 @@ class MessagesHomeScreen extends React.Component<Props, State> {
           heading={I18n.t("messages.tab.archive")}
         >
           <MessagesArchive
+            currentTab={this.state.currentTab}
             messagesState={lexicallyOrderedMessagesState}
             servicesById={servicesById}
             paymentsByRptId={paymentsByRptId}

--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -177,7 +177,7 @@ class MessagesHomeScreen extends React.Component<Props, State> {
     );
   }
 
-  private handleOnScroll = (value: number) => {
+  private handleOnTabsScroll = (value: number) => {
     const { currentTab } = this.state;
     if (Math.abs(value - currentTab) > 0.5) {
       const nextTab = currentTab + (value - currentTab > 0 ? 1 : -1);
@@ -210,7 +210,7 @@ class MessagesHomeScreen extends React.Component<Props, State> {
       <AnimatedTabs
         tabContainerStyle={[styles.tabBarContainer, styles.tabBarUnderline]}
         tabBarUnderlineStyle={styles.tabBarUnderlineActive}
-        onScroll={this.handleOnScroll}
+        onScroll={this.handleOnTabsScroll}
         onChangeTab={this.handleOnChangeTab}
         initialPage={0}
         style={{


### PR DESCRIPTION
With this PR the massive selection of messages is disabled when the user scrolls the tab more than 50% or click in another tab

| BEFORE  | AFTER |
| ------------- | ------------- |
![before-longpress](https://user-images.githubusercontent.com/2670647/72426139-7b7c1c80-3789-11ea-91ea-167b18605084.gif) | ![after-onpress](https://user-images.githubusercontent.com/2670647/72426287-bed68b00-3789-11ea-9c44-ab7a4cea56fd.gif)

