### PR TITLE
[#170920948] Fix email insertion navigation

### DIFF
--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -159,7 +159,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
         ]
       );
     }
-  }
+  };
 
   get isFromProfileSection() {
     return this.props.isOnboardingCompleted;

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -88,7 +88,6 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { email: this.props.optionEmail };
-    this.handleGoBack = this.handleGoBack.bind(this);
   }
 
   private continueOnPress = () => {
@@ -138,7 +137,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
     });
   };
 
-  private handleGoBack() {
+  private handleGoBack = () => {
     if (this.props.isOnboardingCompleted) {
       this.props.navigation.goBack();
     } else {

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -139,7 +139,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
   };
 
   private handleGoBack() {
-    if (this.isOnboardingCompleted) {
+    if (this.props.isOnboardingCompleted) {
       this.props.navigation.goBack();
     } else {
       // if the user is in onboarding phase, go back has to

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -139,9 +139,11 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
   };
 
   private handleGoBack() {
-    if (this.isFromProfileSection) {
+    if (this.isOnboardingCompleted) {
       this.props.navigation.goBack();
     } else {
+      // if the user is in onboarding phase, go back has to
+      // abort login (an user with no email can't access the home)
       Alert.alert(
         I18n.t("onboarding.alert.title"),
         I18n.t("onboarding.alert.description"),
@@ -180,6 +182,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
       } else if (pot.isSome(this.props.profile)) {
         // user is inserting his email from onboarding phase
         if (!this.isFromProfileSection) {
+          // send an ack that user checks his own email
           this.props.acknowledgeEmail();
           return;
         }

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -181,7 +181,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
         showToast(I18n.t("email.edit.upsert_ko"), "danger");
       } else if (pot.isSome(this.props.profile)) {
         // user is inserting his email from onboarding phase
-        if (!this.isFromProfileSection) {
+        if (!this.props.isOnboardingCompleted) {
           // send an ack that user checks his own email
           this.props.acknowledgeEmail();
           return;


### PR DESCRIPTION
**Short description:**
This PR fixes 2 bugs when at login the user hasn't got an email. In the screen where user has to insert a valid email address:
- go back returns to previous screen and the app goes in an invalid navigation state
- continue button returns to previous screen and the app goes in an invalid navigation state


**How to test:**
Run a local server when the profile has an undefined email
`email: undefined`