### PR TITLE
[#170928928] Add logic to handle a profile with no email

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -40,7 +40,7 @@ global:
     search: Text to search
   remoteStates:
     loading: Loading...
-    notAvailable: Non available
+    notAvailable: Not available
   notImplemented: NOT IMPLEMENTED
   search:
     invalidSearchBarText: Enter at least {{minCharacter}} characters
@@ -329,6 +329,7 @@ authentication:
     title: Security notice
     message: To keep your private information safe, please login again with your SPID credentials, thanks!
 email:
+  notAvailable: Not available
   read:
     title: Your email address
     info: This is the email address associated to your SPID account. You can

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -329,7 +329,6 @@ authentication:
     title: Security notice
     message: To keep your private information safe, please login again with your SPID credentials, thanks!
 email:
-  notAvailable: Not available
   read:
     title: Your email address
     info: This is the email address associated to your SPID account. You can

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -335,6 +335,7 @@ authentication:
     title: Avviso di sicurezza
     message: Per mantenere al sicuro i tuoi dati privati, accedi nuovamente con le tue credenziali SPID, grazie!
 email:
+  notAvailable: Not disponibile
   read:
     title: Il tuo indirizzo email
     info: Questo è l'indirizzo email che hai associato all'account SPID. Puoi

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -335,7 +335,6 @@ authentication:
     title: Avviso di sicurezza
     message: Per mantenere al sicuro i tuoi dati privati, accedi nuovamente con le tue credenziali SPID, grazie!
 email:
-  notAvailable: Not disponibile
   read:
     title: Il tuo indirizzo email
     info: Questo è l'indirizzo email che hai associato all'account SPID. Puoi

--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -141,7 +141,7 @@ class PreferencesScreen extends React.Component<Props, State> {
     const { isFingerprintAvailable } = this.state;
 
     const email = this.props.optionEmail.getOrElse(
-      I18n.t("email.notAvailable")
+      I18n.t("global.remoteStates.notAvailable")
     );
     const phoneNumber = potProfile.fold(
       I18n.t("global.remoteStates.notAvailable"),

--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -13,11 +13,13 @@ import I18n from "../../i18n";
 import { getFingerprintSettings } from "../../sagas/startup/checkAcknowledgedFingerprintSaga";
 import {
   navigateToCalendarPreferenceScreen,
+  navigateToEmailInsertScreen,
   navigateToEmailReadScreen,
   navigateToFingerprintPreferenceScreen
 } from "../../store/actions/navigation";
 import { Dispatch, ReduxProps } from "../../store/actions/types";
 import {
+  hasProfileEmailSelector,
   isProfileEmailValidatedSelector,
   profileEmailSelector,
   profileSelector
@@ -81,7 +83,11 @@ class PreferencesScreen extends React.Component<Props, State> {
   }
 
   private handleEmailOnPress() {
-    this.props.navigateToEmailReadScreen();
+    if (this.props.hasProfileEmail) {
+      this.props.navigateToEmailReadScreen();
+      return;
+    }
+    this.props.navigateToEmailInsertScreen();
   }
 
   public componentWillMount() {
@@ -134,7 +140,9 @@ class PreferencesScreen extends React.Component<Props, State> {
     const { potProfile } = this.props;
     const { isFingerprintAvailable } = this.state;
 
-    const email = this.props.optionEmail.getOrElse("");
+    const email = this.props.optionEmail.getOrElse(
+      I18n.t("email.notAvailable")
+    );
     const phoneNumber = potProfile.fold(
       I18n.t("global.remoteStates.notAvailable"),
       _ => _.spid_mobile_phone
@@ -225,7 +233,8 @@ function mapStateToProps(state: GlobalState) {
     optionEmail: profileEmailSelector(state),
     isEmailValidated: isProfileEmailValidatedSelector(state),
     isFingerprintEnabled: state.persistedPreferences.isFingerprintEnabled,
-    preferredCalendar: state.persistedPreferences.preferredCalendar
+    preferredCalendar: state.persistedPreferences.preferredCalendar,
+    hasProfileEmail: hasProfileEmailSelector(state)
   };
 }
 
@@ -234,7 +243,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(navigateToFingerprintPreferenceScreen()),
   navigateToCalendarPreferenceScreen: () =>
     dispatch(navigateToCalendarPreferenceScreen()),
-  navigateToEmailReadScreen: () => dispatch(navigateToEmailReadScreen())
+  navigateToEmailReadScreen: () => dispatch(navigateToEmailReadScreen()),
+  navigateToEmailInsertScreen: () => dispatch(navigateToEmailInsertScreen())
 });
 
 export default connect(

--- a/ts/store/reducers/profile.ts
+++ b/ts/store/reducers/profile.ts
@@ -44,17 +44,22 @@ export const profileEmailSelector = createSelector(
 
 // return true if the profile has an email
 export const hasProfileEmail = (user: InitializedProfile): boolean =>
-  InitializedProfile.is(user) && user.email !== undefined;
+  user.email !== undefined;
+
+// return true if the profile has an email
+export const hasProfileEmailSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): boolean =>
+    pot.getOrElse(pot.map(profile, p => hasProfileEmail(p)), false)
+);
 
 // return true if the profile has an email and it is validated
 export const isProfileEmailValidated = (user: InitializedProfile): boolean =>
-  InitializedProfile.is(user) &&
-  user.is_email_validated !== undefined &&
-  user.is_email_validated === true;
+  user.is_email_validated !== undefined && user.is_email_validated === true;
 
 // return true if the profile has version equals to 0
 export const isProfileFirstOnBoarding = (user: InitializedProfile): boolean =>
-  InitializedProfile.is(user) && user.version === 0;
+  user.version === 0;
 
 // return true if the profile pot is some and its field is_email_validated exists and it's true
 export const isProfileEmailValidatedSelector = createSelector(


### PR DESCRIPTION
**Short description:**
This PR removes some useless type check.

This PR also adds logic to handle a profile with a valid session but with no email (it should not happen)
If the profile has not an email, it is evaluated as **not validated** and the app shows a screen to insert the email address
